### PR TITLE
Subsampling Algorithms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,6 @@ dev-install: ## Locally install project in development mode
 	$(PYTHON_COMMAND) -m pip uninstall -y $(NAME)
 	$(PYTHON_COMMAND) -m pip install -e .
 
+## Testing:
+test:
+	$(PYTHON_COMMAND) -m unittest discover tests -p '*_test.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
   "msgspec>=0.19.0",
   "numpy>=2.3.2",
   "pyyaml>=6.0.2",
+  "h5py>=3.14.0",
+  "pandas>=2.3.2",
+  "scikit-learn>=1.7.1",
+  "scipy>=1.16.1",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "h5py>=3.14.0",
   "pandas>=2.3.2",
   "scikit-learn>=1.7.1",
+  "scikit-learn-extra>=0.3.0",
   "scipy>=1.16.1",
 ]
 

--- a/src/cover_class/subsample/forward_pipeline.py
+++ b/src/cover_class/subsample/forward_pipeline.py
@@ -3,8 +3,6 @@ from torch import FloatTensor, Tensor
 from numpy.typing import NDArray
 import numpy as np
 
-def interior_interpolation(data_matrix: NDArray[np.float32]) -> Tuple[FloatTensor, Tensor, FloatTensor, Tensor]: ... # type: ignore
-
 def train_test_split(data_matrix: NDArray[np.float32], frac_test: float) -> FloatTensor: ... # type: ignore
 
 def prep_data_from_config(config:str) -> Tuple[FloatTensor, Tensor, FloatTensor, Tensor]: ... # type: ignore

--- a/src/cover_class/subsample/forward_pipeline.py
+++ b/src/cover_class/subsample/forward_pipeline.py
@@ -1,8 +1,0 @@
-from typing import Tuple
-from torch import FloatTensor, Tensor
-from numpy.typing import NDArray
-import numpy as np
-
-def train_test_split(data_matrix: NDArray[np.float32], frac_test: float) -> FloatTensor: ... # type: ignore
-
-def prep_data_from_config(config:str) -> Tuple[FloatTensor, Tensor, FloatTensor, Tensor]: ... # type: ignore

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -8,19 +8,24 @@ from scipy.spatial import ConvexHull # type: ignore[import]
 from sklearn.cluster import KMeans # type: ignore[import]
 from sklearn.decomposition import PCA # type: ignore[import]
 
+'''
+All functions in this file are meant to be used on a per-class basis
+'''
+
 # Question: If N_vertices < n_samples, should I just random uniform select the remaining items?
 def convex_hull(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
     Z_c, _ = pca(data_matrix, num_pc)
 
-    hv = np.unique(ConvexHull(Z_c, **kwargs).vertices)
+    hv = ConvexHull(Z_c, **kwargs).vertices
     if n_samples >= hv.size:
         return FloatTensor(torch.from_numpy(data_matrix[hv]).to(torch.float32))
 
+    # Question: should I select like this or uniform select vertices? There're merits to both
     # Farthest point sampling in the set of hull vertices
     V = Z_c[hv]
-    i = np.argmax(np.einsum('ij,ij->i', V, V)) # arbitrary starting point (highest magnitude)
+    i = np.argmax(np.einsum('ij,ij->i', V, V)) # arbitrary starting point (max squared magnitude)
     sel = [i]
-    for _ in range(0, min(n_samples, len(hv))):
+    for _ in range(1, min(n_samples, len(V))):
         d2 = np.sum((V - V[i])**2, axis=1) # PCA in Euclidean space
         d2[np.array(sel)] = -np.inf
         i = np.argmax(d2) # get furthest point from point

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 import numpy as np
 from scipy.spatial import ConvexHull # type: ignore[import]
 from sklearn_extra.cluster import KMedoids # type: ignore[import]
+from sklearn.cluster import KMeans # type: ignore[import]
 from sklearn.decomposition import PCA # type: ignore[import]
 
 '''
@@ -39,6 +40,15 @@ def kmedoids(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwar
     Z_c = pca.fit_transform(data_matrix)
     centroids_idx = KMedoids(n_clusters=n_samples, **kwargs).fit(Z_c).medoid_indices_
     return FloatTensor(torch.from_numpy(data_matrix[centroids_idx]).to(torch.float32))
+
+
+def kmeans(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
+    ''' NOTE: this is only for Euclidean distances '''
+    pca = PCA(n_components=num_pc, svd_solver="arpack", random_state=0)
+    Z_c = pca.fit_transform(data_matrix)
+    centroids_pca = KMeans(n_clusters=n_samples, **kwargs).fit(Z_c).cluster_centers_
+    centroids_spectra = pca.inverse_transform(centroids_pca)
+    return FloatTensor(torch.from_numpy(centroids_spectra).to(torch.float32))
 
 
 def lhs(data_matrix: NDArray[np.float32], num_pc:int, hypercubes_per_dimension:int, samples_per_hypercube:int) -> FloatTensor:

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -37,9 +37,8 @@ def kmedoids(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwar
     ''' NOTE: this is only for Euclidean distances '''
     pca = PCA(n_components=num_pc, svd_solver="arpack", random_state=0)
     Z_c = pca.fit_transform(data_matrix)
-    centroids_pca = KMedoids(n_clusters=n_samples, **kwargs).fit(Z_c).cluster_centers_
-    centroids_spectra = pca.inverse_transform(centroids_pca)
-    return FloatTensor(torch.from_numpy(centroids_spectra).to(torch.float32))
+    centroids_idx = KMedoids(n_clusters=n_samples, **kwargs).fit(Z_c).medoid_indices_
+    return FloatTensor(torch.from_numpy(data_matrix[centroids_idx]).to(torch.float32))
 
 
 def lhs(data_matrix: NDArray[np.float32], num_pc:int, hypercubes_per_dimension:int, samples_per_hypercube:int) -> FloatTensor:

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -1,12 +1,76 @@
+from collections import defaultdict
 from typing import Tuple
-from torch import FloatTensor, Tensor
+from torch import FloatTensor
+import torch
+from numpy.typing import NDArray
+import numpy as np
+from scipy.spatial import ConvexHull # type: ignore[import]
+from sklearn.cluster import KMeans # type: ignore[import]
+from sklearn.decomposition import PCA # type: ignore[import]
 
-def convex_hull(data_matrix: FloatTensor) -> FloatTensor: ... # type: ignore
+# Question: If N_vertices < n_samples, should I just random uniform select the remaining items?
+def convex_hull(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
+    Z_c, _ = pca(data_matrix, num_pc)
 
-def kmeans(data_matrix: FloatTensor) -> FloatTensor: ... # type: ignore
+    hv = np.unique(ConvexHull(Z_c, **kwargs).vertices)
+    if n_samples >= hv.size:
+        return FloatTensor(torch.from_numpy(data_matrix[hv]).to(torch.float32))
 
-def lhs(data_matrix: FloatTensor) -> FloatTensor: ... # type: ignore
+    # Farthest point sampling in the set of hull vertices
+    V = Z_c[hv]
+    i = np.argmax(np.einsum('ij,ij->i', V, V)) # arbitrary starting point (highest magnitude)
+    sel = [i]
+    for _ in range(0, min(n_samples, len(hv))):
+        d2 = np.sum((V - V[i])**2, axis=1) # PCA in Euclidean space
+        d2[np.array(sel)] = -np.inf
+        i = np.argmax(d2) # get furthest point from point
+        sel.append(i)
+        
+    idx = hv[np.array(sel)]
+    return FloatTensor(torch.from_numpy(data_matrix[idx]).to(torch.float32))
 
-def train_test_split(data_matrix: FloatTensor, frac_test: float) -> FloatTensor: ... # type: ignore
 
-def prep_data_from_config(config:str) -> Tuple[FloatTensor, Tensor, FloatTensor, Tensor]: ... # type: ignore
+def kmeans(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
+    ''' NOTE: this is only for Euclidean distances '''
+    pca = PCA(n_components=num_pc, svd_solver="arpack", random_state=0)
+    Z_c = pca.fit_transform(data_matrix)
+    centroids_pca = KMeans(n_clusters=n_samples, **kwargs).fit(Z_c).cluster_centers_
+    centroids_spectra = pca.inverse_transform(centroids_pca)
+    return FloatTensor(torch.from_numpy(centroids_spectra).to(torch.float32))
+
+
+def lhs(data_matrix: NDArray[np.float32], num_pc:int, hypercubes_per_dimension:int, samples_per_hypercube:int) -> FloatTensor:
+    Z_c, _ = pca(data_matrix, num_pc)
+
+    ## Get the min and max bounds for each PC dinmension
+    mins, maxs = Z_c.min(axis=0), Z_c.max(axis=0)
+
+    ## Get the widths of each sub-hypercube to sample from
+    width = (maxs - mins) / hypercubes_per_dimension
+    width[width == 0] = 1.0 # Avoid division by zero if a principal component is constant
+
+    ## Get the indices of each sub-hypercube that each PC dimension of Z falls into
+    idx = np.floor((Z_c - mins)/ width).astype(int)
+    idx = np.clip(idx, 0, hypercubes_per_dimension - 1)
+
+    ## Make a dictionary to get how many points are in each sub-hypercube
+    buckets = defaultdict(list)
+    for local_idx, cube_id in enumerate(map(tuple, idx)):
+        buckets[cube_id].append(local_idx)
+
+    ## Sample the DPs
+    chosen_local: list[int] = []
+    for cube_id, pts in buckets.items():
+        if len(pts) <= samples_per_hypercube:
+            chosen_local.extend(pts)
+        else:
+            chosen_local.extend(np.random.choice(pts, size=samples_per_hypercube, replace=False))
+
+    subsampled_data = data_matrix[np.array(chosen_local)]
+    return FloatTensor(torch.from_numpy(subsampled_data).to(torch.float32)) 
+
+
+def pca(X: np.ndarray, num_pc: int = 6) -> Tuple[np.ndarray, np.ndarray]:
+    pca = PCA(n_components=num_pc, svd_solver="arpack", random_state=0)
+    Z = pca.fit_transform(X)
+    return Z, pca.explained_variance_ratio_

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -5,7 +5,7 @@ import torch
 from numpy.typing import NDArray
 import numpy as np
 from scipy.spatial import ConvexHull # type: ignore[import]
-from sklearn.cluster import KMeans # type: ignore[import]
+from sklearn_extra.cluster import KMedoids # type: ignore[import]
 from sklearn.decomposition import PCA # type: ignore[import]
 
 '''
@@ -33,11 +33,11 @@ def convex_hull(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **k
     return FloatTensor(torch.from_numpy(data_matrix[idx]).to(torch.float32))
 
 
-def kmeans(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
+def kmedoids(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
     ''' NOTE: this is only for Euclidean distances '''
     pca = PCA(n_components=num_pc, svd_solver="arpack", random_state=0)
     Z_c = pca.fit_transform(data_matrix)
-    centroids_pca = KMeans(n_clusters=n_samples, **kwargs).fit(Z_c).cluster_centers_
+    centroids_pca = KMedoids(n_clusters=n_samples, **kwargs).fit(Z_c).cluster_centers_
     centroids_spectra = pca.inverse_transform(centroids_pca)
     return FloatTensor(torch.from_numpy(centroids_spectra).to(torch.float32))
 

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -21,14 +21,14 @@ def convex_hull(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **k
         return FloatTensor(torch.from_numpy(data_matrix[hv]).to(torch.float32))
 
     # Question: should I select like this or uniform select vertices? There're merits to both
-    # Farthest point sampling in the set of hull vertices
+    # Greedy farthest point sampling in the set of hull vertices
     V = Z_c[hv]
     i = np.argmax(np.einsum('ij,ij->i', V, V)) # arbitrary starting point (max squared magnitude)
     sel = [i]
     for _ in range(1, min(n_samples, len(V))):
         d2 = np.sum((V - V[i])**2, axis=1) # PCA in Euclidean space
         d2[np.array(sel)] = -np.inf
-        i = np.argmax(d2) # get furthest point from point
+        i = np.argmax(d2) # Get furthest point from base point
         sel.append(i)
         
     idx = hv[np.array(sel)]

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -54,7 +54,7 @@ def kmeans(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs
 def lhs(data_matrix: NDArray[np.float32], num_pc:int, hypercubes_per_dimension:int, samples_per_hypercube:int) -> FloatTensor:
     Z_c, _ = pca(data_matrix, num_pc)
 
-    ## Get the min and max bounds for each PC dinmension
+    ## Get the min and max bounds for each PC dimension
     mins, maxs = Z_c.min(axis=0), Z_c.max(axis=0)
 
     ## Get the widths of each sub-hypercube to sample from

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -44,7 +44,7 @@ def kmedoids(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwar
 def lhs(data_matrix: NDArray[np.float32], num_pc:int, hypercubes_per_dimension:int, samples_per_hypercube:int) -> FloatTensor:
     Z_c, _ = pca(data_matrix, num_pc)
 
-    ## Get the min and max bounds for each PC dinmension
+    ## Get the min and max bounds for each PC dimension
     mins, maxs = Z_c.min(axis=0), Z_c.max(axis=0)
 
     ## Get the widths of each sub-hypercube to sample from

--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -12,7 +12,6 @@ from sklearn.decomposition import PCA # type: ignore[import]
 All functions in this file are meant to be used on a per-class basis
 '''
 
-# Question: If N_vertices < n_samples, should I just random uniform select the remaining items?
 def convex_hull(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
     Z_c, _ = pca(data_matrix, num_pc)
 
@@ -20,7 +19,6 @@ def convex_hull(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **k
     if n_samples >= hv.size:
         return FloatTensor(torch.from_numpy(data_matrix[hv]).to(torch.float32))
 
-    # Question: should I select like this or uniform select vertices? There're merits to both
     # Greedy farthest point sampling in the set of hull vertices
     V = Z_c[hv]
     i = np.argmax(np.einsum('ij,ij->i', V, V)) # arbitrary starting point (max squared magnitude)

--- a/src/cover_class/subsample/utils.py
+++ b/src/cover_class/subsample/utils.py
@@ -1,0 +1,10 @@
+from typing import Tuple
+from torch import FloatTensor, Tensor
+from numpy.typing import NDArray
+import numpy as np
+
+def interior_interpolation(data_matrix: NDArray[np.float32]) -> Tuple[FloatTensor, Tensor, FloatTensor, Tensor]: ... # type: ignore
+
+def train_test_split(data_matrix: NDArray[np.float32], frac_test: float) -> FloatTensor: ... # type: ignore
+
+def prep_data_from_config(config:str) -> Tuple[FloatTensor, Tensor, FloatTensor, Tensor]: ... # type: ignore

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 from torch import FloatTensor
 import torch
+from sklearn.decomposition import PCA
 
 from cover_class.subsample import subsampler # type: ignore[import]
 
@@ -15,7 +16,6 @@ class subsampleTest(unittest.TestCase):
         self.num_pc = 3
 
     def test_convex_hull(self):
-        '''This just tests that the function itself works'''
         self.preamble()
         n_samples = 3
         sample = subsampler.convex_hull(self.data_matrix, self.num_pc, n_samples)
@@ -26,6 +26,25 @@ class subsampleTest(unittest.TestCase):
 
         sample = subsampler.convex_hull(self.data_matrix, self.num_pc, self.N_datapoints+1)
         self.assertLess(len(sample), self.N_datapoints)
+
+        manual_convex_hull_check = np.array(
+            [[0, 0, 0],
+             [1, 1, 1],
+             [2, 2, 2],
+             [1, 2, 1],
+             [2, 1, 2],
+             [3, 0, 0],
+             [0, 3, 0],
+             [0, 0, 3]]
+        )
+        sample = subsampler.convex_hull(manual_convex_hull_check, 2, len(manual_convex_hull_check))
+        pca = PCA(
+            n_components=2, svd_solver="arpack", random_state=0
+        ).fit_transform(manual_convex_hull_check)
+        vertices = np.unique([int(pca[:,0].argmin()), int(pca[:,0].argmax()), int(pca[:,1].argmin()), int(pca[:,1].argmax())])
+        vertices = torch.from_numpy(manual_convex_hull_check[vertices]).to(dtype=torch.float32)
+        self.assertTrue(all([i in sample for i in vertices]))
+
 
     def test_kmeans(self):
         '''This just tests that the function itself works'''

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -3,7 +3,7 @@ import numpy as np
 from torch import FloatTensor
 import torch
 
-from cover_class.subsample import subsampler
+from cover_class.subsample import subsampler # type: ignore[import]
 
 RANDOM_SEED = 42
 

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -46,11 +46,11 @@ class subsampleTest(unittest.TestCase):
         self.assertTrue(all([i in sample for i in vertices]))
 
 
-    def test_kmeans(self):
+    def test_kmedoids(self):
         '''This just tests that the function itself works'''
         self.preamble()
         n_samples = 10
-        sample = subsampler.kmeans(self.data_matrix, self.num_pc, n_samples)
+        sample = subsampler.kmedoids(self.data_matrix, self.num_pc, n_samples)
         self.assertIsInstance(sample, FloatTensor)
         self.assertEqual(sample.dtype, torch.float32)
         self.assertEqual(len(sample), n_samples)

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -22,7 +22,7 @@ class subsampleTest(unittest.TestCase):
         self.assertIsInstance(sample, FloatTensor)
         self.assertEqual(sample.dtype, torch.float32)
         self.assertEqual(len(sample), n_samples)
-        self.assertEqual(sample.shape[1], self.data_matrix.shape[1])
+        self.assertTrue( np.all(map(lambda x: np.any(np.isclose(x, self.data_matrix)), sample)) )
 
         sample = subsampler.convex_hull(self.data_matrix, self.num_pc, self.N_datapoints+1)
         self.assertLess(len(sample), self.N_datapoints)
@@ -54,7 +54,7 @@ class subsampleTest(unittest.TestCase):
         self.assertIsInstance(sample, FloatTensor)
         self.assertEqual(sample.dtype, torch.float32)
         self.assertEqual(len(sample), n_samples)
-        self.assertEqual(sample.shape[1], self.data_matrix.shape[1])
+        self.assertTrue( np.all(map(lambda x: np.any(np.isclose(x, self.data_matrix)), sample)) )
 
     def test_lhs(self):
         '''This just tests that the function itself works'''
@@ -66,7 +66,7 @@ class subsampleTest(unittest.TestCase):
         self.assertIsInstance(sample, FloatTensor)
         self.assertEqual(sample.dtype, torch.float32)
         self.assertLess(len(sample), ((self.num_pc ** hypercubes_per_dimension)*samples_per_hypercube)+1)
-        self.assertEqual(sample.shape[1], self.data_matrix.shape[1])
+        self.assertTrue( np.all(map(lambda x: np.any(np.isclose(x, self.data_matrix)), sample)) )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -1,0 +1,53 @@
+import unittest
+import numpy as np
+from torch import FloatTensor
+import torch
+
+from cover_class.subsample import subsampler
+
+RANDOM_SEED = 42
+
+class subsampleTest(unittest.TestCase):
+    def preamble(self):
+        np.random.seed(RANDOM_SEED)
+        self.N_datapoints = 1_000
+        self.data_matrix = np.random.random(size=(self.N_datapoints, 500))
+        self.num_pc = 3
+
+    def test_convex_hull(self):
+        '''This just tests that the function itself works'''
+        self.preamble()
+        n_samples = 3
+        sample = subsampler.convex_hull(self.data_matrix, self.num_pc, n_samples)
+        self.assertIsInstance(sample, FloatTensor)
+        self.assertEqual(sample.dtype, torch.float32)
+        self.assertEqual(len(sample), n_samples)
+        self.assertEqual(sample.shape[1], self.data_matrix.shape[1])
+
+        sample = subsampler.convex_hull(self.data_matrix, self.num_pc, self.N_datapoints+1)
+        self.assertLess(len(sample), self.N_datapoints)
+
+    def test_kmeans(self):
+        '''This just tests that the function itself works'''
+        self.preamble()
+        n_samples = 10
+        sample = subsampler.kmeans(self.data_matrix, self.num_pc, n_samples)
+        self.assertIsInstance(sample, FloatTensor)
+        self.assertEqual(sample.dtype, torch.float32)
+        self.assertEqual(len(sample), n_samples)
+        self.assertEqual(sample.shape[1], self.data_matrix.shape[1])
+
+    def test_lhs(self):
+        '''This just tests that the function itself works'''
+        self.preamble()
+        hypercubes_per_dimension = 3
+        samples_per_hypercube = 5
+
+        sample = subsampler.lhs(self.data_matrix, self.num_pc, hypercubes_per_dimension, samples_per_hypercube)
+        self.assertIsInstance(sample, FloatTensor)
+        self.assertEqual(sample.dtype, torch.float32)
+        self.assertLess(len(sample), ((self.num_pc ** hypercubes_per_dimension)*samples_per_hypercube)+1)
+        self.assertEqual(sample.shape[1], self.data_matrix.shape[1])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from torch import FloatTensor
 import torch
-from sklearn.decomposition import PCA
+from sklearn.decomposition import PCA # type: ignore[import]
 
 from cover_class.subsample import subsampler # type: ignore[import]
 

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -45,6 +45,15 @@ class subsampleTest(unittest.TestCase):
         vertices = torch.from_numpy(manual_convex_hull_check[vertices]).to(dtype=torch.float32)
         self.assertTrue(all([i in sample for i in vertices]))
 
+    def test_kmeans(self):
+        '''This just tests that the function itself works'''
+        self.preamble()
+        n_samples = 10
+        sample = subsampler.kmeans(self.data_matrix, self.num_pc, n_samples)
+        self.assertIsInstance(sample, FloatTensor)
+        self.assertEqual(sample.dtype, torch.float32)
+        self.assertEqual(len(sample), n_samples)
+        self.assertTrue( np.all(map(lambda x: np.any(np.isclose(x, self.data_matrix)), sample)) )
 
     def test_kmedoids(self):
         '''This just tests that the function itself works'''


### PR DESCRIPTION
## Overview
This PR is to add in the subsampling functionality. It does not build the full pipeline, but it builds out the portion of the code where the subsampling actually occurs. 

The sampling options are:
1. convex-hull vertices 
2. k-medoid centroids
3. latin hyper cube sampling

All of these are done in PCA space and translated back to spectral space.

There is the policy that the functions should only be used on a per-class basis, not with multi-class data. 

## Related Tickets

## Testing
The testing that was done was light-weight runtime validation. 
Run `make test` on this branch to verify the tests.