### PR TITLE
Dataloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,6 @@ dev-install: ## Locally install project in development mode
 	$(PYTHON_COMMAND) -m pip uninstall -y $(NAME)
 	$(PYTHON_COMMAND) -m pip install -e .
 
+## Testing:
+test:
+	$(PYTHON_COMMAND) -m unittest discover tests -p '*_test.py'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ dataloader: OrchestratorDataset = dataloader_from_config(
     my_config_path, 
     data_train, 
     labels_train,
-    batch_size
+    batch_size,
+    shuffle
 )
 ```

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 ### Train Time
 ```
 from cover_class.subsample import prep_data_from_config
-from cover_class.dataloader import OrchestratorDataLoader, dataloader_from_config
+from cover_class.dataloader import OrchestratorDataset, dataloader_from_config
 
 my_config_path = '/my/path/config.yaml'
 data_train, labels_train, data_test, labels_test = prep_data_from_config(my_config_path)
-dataloader: OrchestratorDataLoader = dataloader_from_config(
+dataloader: OrchestratorDataset = dataloader_from_config(
     my_config_path, 
     data_train, 
     labels_train,

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 ## Example Usage
 ### Train Time
 ```
+from torch.utils.data import DataLoader
 from cover_class.subsample import prep_data_from_config
 from cover_class.dataloader import OrchestratorDataset, dataloader_from_config
 
 my_config_path = '/my/path/config.yaml'
 data_train, labels_train, data_test, labels_test = prep_data_from_config(my_config_path)
-dataloader: OrchestratorDataset = dataloader_from_config(
+dataloader: DataLoader = dataloader_from_config( # the DataLoader has the OrchestratorDataset generator
     my_config_path, 
     data_train, 
     labels_train,

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -13,4 +13,5 @@ simulation:
   alpha: 0.3
   min-frac: 0.1
   noise-file: example.csv
-
+dataloader:
+  percent-static-data: 0.5

--- a/src/cover_class/dataloader/__init__.py
+++ b/src/cover_class/dataloader/__init__.py
@@ -1,11 +1,11 @@
 from cover_class.dataloader.dataloader import (
-    OrchestratorDataLoader,
-    OrchestratorDataLoaderArgs,
+    OrchestratorDataset,
+    OrchestratorDatasetArgs,
     dataloader_from_config
 )
 
 __all__ = [
-    "OrchestratorDataLoader",
-    "OrchestratorDataLoaderArgs",
+    "OrchestratorDataset",
+    "OrchestratorDatasetArgs",
     "dataloader_from_config",
 ]

--- a/src/cover_class/dataloader/__init__.py
+++ b/src/cover_class/dataloader/__init__.py
@@ -1,7 +1,11 @@
 from cover_class.dataloader.dataloader import (
     OrchestratorDataLoader,
+    OrchestratorDataLoaderArgs,
+    dataloader_from_config
 )
 
 __all__ = [
     "OrchestratorDataLoader",
+    "OrchestratorDataLoaderArgs",
+    "dataloader_from_config",
 ]

--- a/src/cover_class/dataloader/const.py
+++ b/src/cover_class/dataloader/const.py
@@ -1,1 +1,0 @@
-MAX_DATALOADER_VALUE = (1 << 64) - 1

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -4,7 +4,12 @@ from torch import FloatTensor, Tensor, CharTensor
 from torch.utils.data import DataLoader
 from msgspec import Struct
 
-from cover_class.simulation import run_simulation, SimulationArgs, DataArgs
+from cover_class.simulation import (
+    run_simulation, 
+    args_from_config, 
+    SimulationArgs, 
+    DataArgs
+)
 from cover_class.utils import read_config
 
 
@@ -43,7 +48,7 @@ class OrchestratorDataLoader(DataLoader):
         - The static and simulated data will be generated/retrieved on a per-batch basis
     '''
     args: OrchestratorDataLoaderArgs
-    device: Optional[torch.device] = None
+    device: torch.device = torch.device("cpu")
     shuffle = True
 
     step = 0
@@ -57,7 +62,7 @@ class OrchestratorDataLoader(DataLoader):
     def __init__(self, 
                 args: OrchestratorDataLoaderArgs, 
                 shuffle: bool = True, 
-                device: Optional[torch.device] = None
+                device: torch.device = torch.device("cpu"),
             ) -> None:
         self.args = args; self.shuffle = shuffle; self.device = device
         if self.args._using_static: self.__shuffle__()
@@ -104,15 +109,25 @@ class OrchestratorDataLoader(DataLoader):
         if self.args.static_data is None: return None
         return int(len(self.args.static_data) / self.args.percent_static)
 
-def dataloader_from_config( # type: ignore
-        config_path:str, 
+def dataloader_from_config(
+        config: Dict|str, 
         spectra:FloatTensor,
         labels:Tensor,
         batch_size:int,
-    ) -> OrchestratorDataLoader: 
-    config = read_config(config_path)
-    # Dataloader:
-    # 1. build the dataloader args
-    # 2. build the simulation args
-    # 3. build dataloader
-    ...
+        shuffle: bool = True, 
+        device: torch.device = torch.device("cpu"),
+    ) -> OrchestratorDataLoader:
+
+    config = read_config(config)
+    sim_config_args, sim_data_args = args_from_config(config, batch_size)
+
+    odl_args = OrchestratorDataLoaderArgs(
+        batch_size,
+        config["dataloader"]["percent-static-data"],
+        sim_config_args,
+        sim_data_args,
+        spectra,
+        labels
+    )
+    odl_args._method_selection_idxs = CharTensor(odl_args._method_selection_idxs.to(device))
+    return OrchestratorDataLoader(odl_args, shuffle, device)

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -2,7 +2,7 @@ from typing import *
 import torch
 from torch import FloatTensor, Tensor, CharTensor
 from torch.utils.data import DataLoader
-from msgspec import Struct
+from msgspec import Struct, field
 
 from cover_class.simulation import (
     run_simulation, 
@@ -23,11 +23,11 @@ class OrchestratorDataLoaderArgs(Struct):
     static_data: Optional[torch.FloatTensor]
     static_labels: Optional[torch.Tensor]
 
-    _using_static = False
-    _using_sim = False
+    _using_static: bool = field(default=False)
+    _using_sim: bool   = field(default=False)
 
     # This tells you the ids out of a 100 batches, which ones will be static/simulated
-    _method_selection_idxs: CharTensor = CharTensor(torch.zeros(100, dtype=torch.int8))
+    _method_selection_idxs: CharTensor = field(default_factory=lambda: CharTensor(torch.zeros(100, dtype=torch.int8)))
 
     def __post_init__(self):
         self._using_static = (self.static_labels is not None) and (self.static_data is not None)
@@ -48,7 +48,6 @@ class OrchestratorDataLoader(DataLoader):
         - The static and simulated data will be generated/retrieved on a per-batch basis
     '''
     args: OrchestratorDataLoaderArgs
-    device: torch.device = torch.device("cpu")
     shuffle = True
 
     step = 0
@@ -62,9 +61,8 @@ class OrchestratorDataLoader(DataLoader):
     def __init__(self, 
                 args: OrchestratorDataLoaderArgs, 
                 shuffle: bool = True, 
-                device: torch.device = torch.device("cpu"),
             ) -> None:
-        self.args = args; self.shuffle = shuffle; self.device = device
+        self.args = args; self.shuffle = shuffle
         if self.args._using_static: self.__shuffle__()
 
     def __next__(self) -> Tuple[torch.FloatTensor, torch.Tensor]:
@@ -74,7 +72,7 @@ class OrchestratorDataLoader(DataLoader):
             self.is_simulated_batch = False
             start =  (self.static_epoch_step * self.args.batch_size)
             end   = ((self.static_epoch_step+1) * self.args.batch_size)
-            # mypy doesn't catch self._using_static
+            # mypy doesn't catch self.args._using_static
             idx = self._static_idx_order[start: end] # type: ignore
             self.static_samples_seen += len(idx)
             if end >= len(self.args.static_data)-1: # type: ignore
@@ -84,6 +82,7 @@ class OrchestratorDataLoader(DataLoader):
         
         elif self.args._using_sim:
             self.is_simulated_batch = True
+            # mypy doesn't catch self.args._using_sim
             return run_simulation(self.args.sim_config_args, self.args.sim_data_args) # type: ignore
         
         else: raise StopIteration()
@@ -91,10 +90,8 @@ class OrchestratorDataLoader(DataLoader):
     def __shuffle__(self) -> None:
         if self.shuffle:
             self._static_idx_order = CharTensor(torch.randperm(
-                # I don't want to need a check every time here - caller's responsibility
-                self.args.static_labels.nelement(), # type: ignore
+                self.args.static_labels.nelement(), # type: ignore # caller's responsibility
                 dtype=torch.int8, 
-                device=self.device
             ))
         
     def __reset__(self) -> None:
@@ -115,7 +112,6 @@ def dataloader_from_config(
         labels:Tensor,
         batch_size:int,
         shuffle: bool = True, 
-        device: torch.device = torch.device("cpu"),
     ) -> OrchestratorDataLoader:
 
     config = read_config(config)
@@ -129,5 +125,4 @@ def dataloader_from_config(
         spectra,
         labels
     )
-    odl_args._method_selection_idxs = CharTensor(odl_args._method_selection_idxs.to(device))
-    return OrchestratorDataLoader(odl_args, shuffle, device)
+    return OrchestratorDataLoader(odl_args, shuffle)

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -117,7 +117,7 @@ def dataloader_from_config(
     ) -> DataLoader:
 
     config = read_config(config)
-    sim_config_args, sim_data_args = args_from_config(config, batch_size)
+    sim_config_args, sim_data_args = args_from_config(config, spectra, labels, batch_size)
 
     ods_args = OrchestratorDatasetArgs(
         batch_size,

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -3,7 +3,6 @@ import torch
 from torch import FloatTensor, Tensor, CharTensor
 from torch.utils.data import DataLoader
 from msgspec import Struct
-from pathlib import Path
 import math
 
 from cover_class.simulation import run_simulation, SimulationArgs, DataArgs
@@ -13,16 +12,12 @@ from cover_class.utils import read_config
 class OrchestratorDataLoaderArgs(Struct):
     batch_size: int
     percent_static: float
-    output_path: str # this param isn't necessary but could be convenient for users
 
     static_data: Optional[torch.FloatTensor]
     static_labels: Optional[torch.Tensor]
 
     sim_args: SimulationArgs
     data_args: DataArgs
-
-    def __post_init__(self):
-        Path.is_dir(Path(self.output_path))
 
 
 class OrchestratorDataLoader(DataLoader):
@@ -36,7 +31,7 @@ class OrchestratorDataLoader(DataLoader):
     device: Optional[torch.device] = None
     shuffle = True
 
-    step = 0 
+    step = 0
     static_epoch = 0
     static_epoch_step = 0
     static_samples_seen = 0
@@ -69,7 +64,6 @@ class OrchestratorDataLoader(DataLoader):
             return self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
         
         self.is_simulated_batch = True
-        # TODO: need to return simulated data
         return run_simulation(self.args.sim_args, self.args.data_args)
         
     def __static_batch_predicate__(self) -> bool:

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -4,12 +4,8 @@ from torch import FloatTensor, Tensor, CharTensor, LongTensor
 from torch.utils.data import IterableDataset, DataLoader
 from msgspec import Struct, field
 
-from cover_class.simulation import (
-    run_simulation, 
-    args_from_config, 
-    SimulationArgs, 
-    DataArgs
-)
+from cover_class.simulation import args_from_config, SimulationArgs, DataArgs
+import cover_class.simulation as sim
 from cover_class.utils import read_config
 
 
@@ -46,6 +42,13 @@ class OrchestratorDataset(IterableDataset):
 
     Data Policy:
         - The static and simulated data will be generated/retrieved on a per-batch basis
+
+    Example use:
+    >>> old = OrchestratorDataset(args)
+    >>> dl = DataLoader(old, batch_size=None)
+    >>> # NOTE: The `batch_size` in the dataloader must be set to `None`
+    >>> for X, Y in dl:
+    >>>     ...
     '''
     args: OrchestratorDatasetArgs
     shuffle = True
@@ -68,6 +71,7 @@ class OrchestratorDataset(IterableDataset):
     def __iter__(self) -> Iterator[Tuple[torch.FloatTensor, torch.Tensor]]:
         ''' This iterator does not stop '''
         while True:
+            self.step += 1
             if self.args._using_static and self.__use_static_predicate__():
                 self.is_simulated_batch = False
                 start =  (self.static_epoch_step * self.args.batch_size)
@@ -83,17 +87,16 @@ class OrchestratorDataset(IterableDataset):
             elif self.args._using_sim:
                 self.is_simulated_batch = True
                 # mypy doesn't catch self.args._using_sim
-                yield run_simulation(self.args.sim_config_args, self.args.sim_data_args) # type: ignore
+                yield sim.run_simulation(self.args.sim_config_args, self.args.sim_data_args) # type: ignore
 
             else: raise StopIteration()
-
             
     def __shuffle__(self) -> None:
         if self.shuffle:
             self._static_idx_order = LongTensor(torch.randperm(
                 self.args.static_labels.nelement(), # type: ignore # caller's responsibility
                 device=self.args.static_labels.device, # type: ignore
-                dtype=torch.uint64, 
+                dtype=torch.int64, 
             ))
         
     def __reset__(self) -> None:
@@ -119,7 +122,7 @@ def dataloader_from_config(
     config = read_config(config)
     sim_config_args, sim_data_args = args_from_config(config, batch_size)
 
-    odl_args = OrchestratorDatasetArgs(
+    ods_args = OrchestratorDatasetArgs(
         batch_size,
         config["dataloader"]["percent-static-data"],
         sim_config_args,
@@ -127,5 +130,5 @@ def dataloader_from_config(
         spectra,
         labels
     )
-    old = OrchestratorDataset(odl_args, shuffle)
-    return DataLoader(old, batch_size=None)
+    ods = OrchestratorDataset(ods_args, shuffle)
+    return DataLoader(ods, batch_size=None)

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -6,7 +6,7 @@ from msgspec import Struct
 from pathlib import Path
 import math
 
-from cover_class.simulation import run_simulation, SimulationArgs
+from cover_class.simulation import run_simulation, SimulationArgs, DataArgs
 from cover_class.dataloader.const import *
 from cover_class.utils import read_config
 
@@ -14,16 +14,16 @@ from cover_class.utils import read_config
 class OrchestratorDataLoaderArgs(Struct):
     batch_size: int
     percent_static: float
-    output_path:str
-    checkpoint_path:Optional[str]
-    static_data:Optional[torch.FloatTensor]
-    static_labels:Optional[torch.Tensor]
-    sim_args:Optional[SimulationArgs]
+    output_path: str # this param isn't necessary but could be convenient for users
+
+    static_data: Optional[torch.FloatTensor]
+    static_labels: Optional[torch.Tensor]
+
+    sim_args: SimulationArgs
+    data_args: DataArgs
 
     def __post_init__(self):
         Path.is_dir(Path(self.output_path))
-        if self.checkpoint_path:
-            assert Path.is_dir(Path(self.checkpoint_path))    
 
 
 class OrchestratorDataLoader(DataLoader):
@@ -71,7 +71,7 @@ class OrchestratorDataLoader(DataLoader):
         
         self.is_simulated_batch = True
         # TODO: need to return simulated data
-        return ... # type: ignore
+        return run_simulation(self.args.sim_args, self.args.data_args)
         
     def __static_batch_predicate__(self) -> bool:
         return math.floor((self.static_epoch_step + 1) * self.args.percent_static) == math.floor(self.static_epoch_step * self.args.percent_static)

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -106,10 +106,7 @@ class OrchestratorDataset(IterableDataset):
 
     def __use_static_predicate__(self) -> bool:
         return bool(self.args._method_selection_idxs[(self.step % 100)])
-    
-    def static_epoch_len(self) -> Optional[int]:
-        if self.args.static_data is None: return None
-        return int(len(self.args.static_data) / self.args.percent_static)
+
 
 def dataloader_from_config(
         config: Dict|str, 

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -13,11 +13,27 @@ class OrchestratorDataLoaderArgs(Struct):
     batch_size: int
     percent_static: float
 
+    sim_config_args: Optional[SimulationArgs]
+    sim_data_args: Optional[DataArgs]
+
     static_data: Optional[torch.FloatTensor]
     static_labels: Optional[torch.Tensor]
 
-    sim_args: SimulationArgs
-    data_args: DataArgs
+    _using_static = False
+    _using_sim = False
+
+    # This tells you the ids out of a 100 batches, which ones will be static/simulated
+    _method_selection_idxs: CharTensor = CharTensor(torch.zeros(100, dtype=torch.int8))
+
+    def __post_init__(self):
+        self._using_static = (self.static_labels is not None) and (self.static_data is not None)
+        self._using_sim = (self.sim_config_args is not None) and (self.sim_data_args is not None)
+        assert self._using_static or self._using_sim, "Need to provide either simulation or static data arguments"
+        if self._using_static and not self._using_sim: self.percent_static = 100.
+        elif not self._using_static: self.percent_static = 0.
+        assert (self.percent_static is not None) and (0. <= self.percent_static <= 100.), "'percent_static' needs to be between [0, 100]"
+
+        self._method_selection_idxs[:int(self.percent_static)] = 1
 
 
 class OrchestratorDataLoader(DataLoader):
@@ -38,7 +54,6 @@ class OrchestratorDataLoader(DataLoader):
     is_simulated_batch = False
 
     _static_idx_order: Optional[CharTensor] = None
-    _using_static = False
 
     def __init__(self, 
                 args: OrchestratorDataLoaderArgs, 
@@ -46,29 +61,29 @@ class OrchestratorDataLoader(DataLoader):
                 device: Optional[torch.device] = None
             ) -> None:
         self.args = args; self.shuffle = shuffle; self.device = device
-        self._using_static = (self.args.static_labels is not None) and (self.args.static_data is not None)
-        if self._using_static: self.__shuffle__()
+        if self.args._using_static: self.__shuffle__()
 
-    def __iter__(self) -> Tuple[torch.FloatTensor, torch.Tensor]: # type: ignore
+    def __next__(self) -> Tuple[torch.FloatTensor, torch.Tensor]:
         ''' This iterator does not stop '''
         self.step += 1
-        if self._using_static and self.__static_batch_predicate__():
+        if self.args._using_static and self.__use_static_predicate__():
             self.is_simulated_batch = False
             start =  (self.static_epoch_step * self.args.batch_size)
             end   = ((self.static_epoch_step+1) * self.args.batch_size)
             # mypy doesn't catch self._using_static
             idx = self._static_idx_order[start: end] # type: ignore
             self.static_samples_seen += len(idx)
-            if end >= len(self.args.static_data)-1: self.__reset__() # type: ignore
+            if end >= len(self.args.static_data)-1: # type: ignore
+                self.__reset__()
 
             return self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
         
-        self.is_simulated_batch = True
-        return run_simulation(self.args.sim_args, self.args.data_args)
+        elif self.args._using_sim:
+            self.is_simulated_batch = True
+            return run_simulation(self.args.sim_config_args, self.args.sim_data_args) # type: ignore
         
-    def __static_batch_predicate__(self) -> bool:
-        return math.floor((self.static_epoch_step + 1) * self.args.percent_static) == math.floor(self.static_epoch_step * self.args.percent_static)
-    
+        else: raise StopIteration()
+            
     def __shuffle__(self) -> None:
         if self.shuffle:
             self._static_idx_order = CharTensor(torch.randperm(
@@ -82,6 +97,9 @@ class OrchestratorDataLoader(DataLoader):
         self.static_epoch += 1
         self.static_epoch_step = 0
         self.__shuffle__()
+
+    def __use_static_predicate__(self) -> bool:
+        return bool(self.args._method_selection_idxs[(self.step % 100)])
     
     def static_epoch_len(self) -> Optional[int]:
         if self.args.static_data is None: return None

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -1,9 +1,10 @@
 from typing import *
 import torch
-from torch import FloatTensor, Tensor
-from torch.utils.data import Dataset
+from torch import FloatTensor, Tensor, CharTensor
+from torch.utils.data import DataLoader
 from msgspec import Struct
 from pathlib import Path
+import math
 
 from cover_class.simulation import run_simulation, SimulationArgs
 from cover_class.dataloader.const import *
@@ -25,20 +26,69 @@ class OrchestratorDataLoaderArgs(Struct):
             assert Path.is_dir(Path(self.checkpoint_path))    
 
 
-class OrchestratorDataLoader(Dataset):
+class OrchestratorDataLoader(DataLoader):
     '''
+    OrchestratorDataLoader is a non-terminating iterator. Caller must institute it's own break.
+
     Data Policy:
         - The static and simulated data will be generated/retrieved on a per-batch basis
     '''
     args: OrchestratorDataLoaderArgs
-    state: Dict = {
-        'iter':0,
-        'epoch':0,
-    }
+    device: Optional[torch.device] = None
+    shuffle = True
 
-    def __init__(self, args:OrchestratorDataLoaderArgs, shuffle=False) -> None: ...
+    step = 0 
+    static_epoch = 0
+    static_epoch_step = 0
+    static_samples_seen = 0
+    is_simulated_batch = False
 
-    def __get_item__(self, idx) -> Tuple[torch.Tensor, torch.Tensor]: ... # type: ignore
+    _static_idx_order: Optional[CharTensor] = None
+    _using_static = False
+
+    def __init__(self, 
+                args: OrchestratorDataLoaderArgs, 
+                shuffle: bool = True, 
+                device: Optional[torch.device] = None
+            ) -> None:
+        self.args = args; self.shuffle = shuffle; self.device = device
+        self._using_static = (self.args.static_labels is not None) and (self.args.static_data is not None)
+        if self._using_static: self.__shuffle__()
+
+    def __iter__(self) -> Tuple[torch.FloatTensor, torch.Tensor]: # type: ignore
+        ''' This iterator does not stop '''
+        self.step += 1
+        if self._using_static and self.__static_batch_predicate__():
+            self.is_simulated_batch = False
+            start =  (self.static_epoch_step * self.args.batch_size)
+            end   = ((self.static_epoch_step+1) * self.args.batch_size)
+            # mypy doesn't catch self._using_static
+            idx = self._static_idx_order[start: end] # type: ignore
+            self.static_samples_seen += len(idx)
+            if end >= len(self.args.static_data)-1: self.__reset__() # type: ignore
+            
+            return self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
+        
+        self.is_simulated_batch = True
+        # TODO: need to return simulated data
+        return ... # type: ignore
+        
+    def __static_batch_predicate__(self) -> bool:
+        return math.floor((self.static_epoch_step + 1) * self.args.batch_size) != math.floor(self.static_epoch_step * self.args.batch_size)
+    
+    def __shuffle__(self) -> None:
+        if self.shuffle:
+            self._static_idx_order = CharTensor(torch.randperm(
+                # I don't want to need a check every time here - caller's responsibility
+                self.args.static_labels.nelement(), # type: ignore
+                dtype=torch.int8, 
+                device=self.device
+            ))
+        
+    def __reset__(self) -> None:
+        self.static_epoch += 1
+        self.static_epoch_step = 0
+        self.__shuffle__()
     
     def __len__(self) -> int:
         if self.args.static_data is not None:

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -3,7 +3,6 @@ import torch
 from torch import FloatTensor, Tensor, CharTensor
 from torch.utils.data import DataLoader
 from msgspec import Struct
-import math
 
 from cover_class.simulation import run_simulation, SimulationArgs, DataArgs
 from cover_class.utils import read_config

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -80,7 +80,7 @@ class OrchestratorDataset(IterableDataset):
                 # mypy doesn't catch self.args._using_static
                 idx = self._static_idx_order[start: end] # type: ignore
                 self.static_samples_seen += len(idx)
-                if end >= len(self.args.static_data)-1: # type: ignore
+                if end >= len(self.args.static_data): # type: ignore
                     self.__reset__()
                 yield self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
 

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import math
 
 from cover_class.simulation import run_simulation, SimulationArgs, DataArgs
-from cover_class.dataloader.const import *
 from cover_class.utils import read_config
 
 
@@ -90,11 +89,9 @@ class OrchestratorDataLoader(DataLoader):
         self.static_epoch_step = 0
         self.__shuffle__()
     
-    def __len__(self) -> int:
-        if self.args.static_data is not None:
-            return int(len(self.args.static_data) / self.args.percent_static)
-        return MAX_DATALOADER_VALUE
-
+    def static_epoch_len(self) -> Optional[int]:
+        if self.args.static_data is None: return None
+        return int(len(self.args.static_data) / self.args.percent_static)
 
 def dataloader_from_config( # type: ignore
         config_path:str, 

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -66,7 +66,7 @@ class OrchestratorDataLoader(DataLoader):
             idx = self._static_idx_order[start: end] # type: ignore
             self.static_samples_seen += len(idx)
             if end >= len(self.args.static_data)-1: self.__reset__() # type: ignore
-            
+
             return self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
         
         self.is_simulated_batch = True
@@ -74,7 +74,7 @@ class OrchestratorDataLoader(DataLoader):
         return ... # type: ignore
         
     def __static_batch_predicate__(self) -> bool:
-        return math.floor((self.static_epoch_step + 1) * self.args.batch_size) != math.floor(self.static_epoch_step * self.args.batch_size)
+        return math.floor((self.static_epoch_step + 1) * self.args.percent_static) == math.floor(self.static_epoch_step * self.args.percent_static)
     
     def __shuffle__(self) -> None:
         if self.shuffle:

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -80,7 +80,7 @@ class OrchestratorDataset(IterableDataset):
                 # mypy doesn't catch self.args._using_static
                 idx = self._static_idx_order[start: end] # type: ignore
                 self.static_samples_seen += len(idx)
-                if end >= len(self.args.static_data): # type: ignore
+                if end >= len(self.args.static_data)-1: # type: ignore
                     self.__reset__()
                 yield self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
 

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -1,7 +1,7 @@
 from typing import *
 import torch
-from torch import FloatTensor, Tensor, CharTensor
-from torch.utils.data import DataLoader
+from torch import FloatTensor, Tensor, CharTensor, LongTensor
+from torch.utils.data import IterableDataset, DataLoader
 from msgspec import Struct, field
 
 from cover_class.simulation import (
@@ -13,7 +13,7 @@ from cover_class.simulation import (
 from cover_class.utils import read_config
 
 
-class OrchestratorDataLoaderArgs(Struct):
+class OrchestratorDatasetArgs(Struct):
     batch_size: int
     percent_static: float
 
@@ -40,14 +40,14 @@ class OrchestratorDataLoaderArgs(Struct):
         self._method_selection_idxs[:int(self.percent_static)] = 1
 
 
-class OrchestratorDataLoader(DataLoader):
+class OrchestratorDataset(IterableDataset):
     '''
-    OrchestratorDataLoader is a non-terminating iterator. Caller must institute it's own break.
+    OrchestratorDataset is a non-terminating iterator. Caller must institute it's own break.
 
     Data Policy:
         - The static and simulated data will be generated/retrieved on a per-batch basis
     '''
-    args: OrchestratorDataLoaderArgs
+    args: OrchestratorDatasetArgs
     shuffle = True
 
     step = 0
@@ -56,42 +56,44 @@ class OrchestratorDataLoader(DataLoader):
     static_samples_seen = 0
     is_simulated_batch = False
 
-    _static_idx_order: Optional[CharTensor] = None
+    _static_idx_order: Optional[LongTensor] = None
 
     def __init__(self, 
-                args: OrchestratorDataLoaderArgs, 
+                args: OrchestratorDatasetArgs, 
                 shuffle: bool = True, 
             ) -> None:
         self.args = args; self.shuffle = shuffle
         if self.args._using_static: self.__shuffle__()
 
-    def __next__(self) -> Tuple[torch.FloatTensor, torch.Tensor]:
+    def __iter__(self) -> Iterator[Tuple[torch.FloatTensor, torch.Tensor]]:
         ''' This iterator does not stop '''
-        self.step += 1
-        if self.args._using_static and self.__use_static_predicate__():
-            self.is_simulated_batch = False
-            start =  (self.static_epoch_step * self.args.batch_size)
-            end   = ((self.static_epoch_step+1) * self.args.batch_size)
-            # mypy doesn't catch self.args._using_static
-            idx = self._static_idx_order[start: end] # type: ignore
-            self.static_samples_seen += len(idx)
-            if end >= len(self.args.static_data)-1: # type: ignore
-                self.__reset__()
+        while True:
+            if self.args._using_static and self.__use_static_predicate__():
+                self.is_simulated_batch = False
+                start =  (self.static_epoch_step * self.args.batch_size)
+                end   = ((self.static_epoch_step+1) * self.args.batch_size)
+                self.static_epoch_step += 1
+                # mypy doesn't catch self.args._using_static
+                idx = self._static_idx_order[start: end] # type: ignore
+                self.static_samples_seen += len(idx)
+                if end >= len(self.args.static_data)-1: # type: ignore
+                    self.__reset__()
+                yield self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
 
-            return self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
-        
-        elif self.args._using_sim:
-            self.is_simulated_batch = True
-            # mypy doesn't catch self.args._using_sim
-            return run_simulation(self.args.sim_config_args, self.args.sim_data_args) # type: ignore
-        
-        else: raise StopIteration()
+            elif self.args._using_sim:
+                self.is_simulated_batch = True
+                # mypy doesn't catch self.args._using_sim
+                yield run_simulation(self.args.sim_config_args, self.args.sim_data_args) # type: ignore
+
+            else: raise StopIteration()
+
             
     def __shuffle__(self) -> None:
         if self.shuffle:
-            self._static_idx_order = CharTensor(torch.randperm(
+            self._static_idx_order = LongTensor(torch.randperm(
                 self.args.static_labels.nelement(), # type: ignore # caller's responsibility
-                dtype=torch.int8, 
+                device=self.args.static_labels.device, # type: ignore
+                dtype=torch.uint64, 
             ))
         
     def __reset__(self) -> None:
@@ -112,12 +114,12 @@ def dataloader_from_config(
         labels:Tensor,
         batch_size:int,
         shuffle: bool = True, 
-    ) -> OrchestratorDataLoader:
+    ) -> DataLoader:
 
     config = read_config(config)
     sim_config_args, sim_data_args = args_from_config(config, batch_size)
 
-    odl_args = OrchestratorDataLoaderArgs(
+    odl_args = OrchestratorDatasetArgs(
         batch_size,
         config["dataloader"]["percent-static-data"],
         sim_config_args,
@@ -125,4 +127,5 @@ def dataloader_from_config(
         spectra,
         labels
     )
-    return OrchestratorDataLoader(odl_args, shuffle)
+    old = OrchestratorDataset(odl_args, shuffle)
+    return DataLoader(old, batch_size=None)

--- a/src/cover_class/simulation/__init__.py
+++ b/src/cover_class/simulation/__init__.py
@@ -1,11 +1,13 @@
 from cover_class.simulation.simulate import (
     run_simulation,
+    args_from_config,
     SimulationArgs,
     DataArgs,
 )
 
 __all__ = [
     "run_simulation",
+    "args_from_config",
     "SimulationArgs",
     "DataArgs"
 ]

--- a/src/cover_class/simulation/__init__.py
+++ b/src/cover_class/simulation/__init__.py
@@ -1,9 +1,11 @@
 from cover_class.simulation.simulate import (
     run_simulation,
     SimulationArgs,
+    DataArgs,
 )
 
 __all__ = [
     "run_simulation",
     "SimulationArgs",
+    "DataArgs"
 ]

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple, Dict
 from msgspec import Struct
 import numpy as np
 import numpy.typing as npt
-from torch import FloatTensor, ByteTensor
+from torch import FloatTensor, ByteTensor, Tensor
 
 from cover_class.simulation.const import *
 
@@ -20,6 +20,6 @@ class DataArgs(Struct):
     class_targets: npt.NDArray[np.int8]
     wavelengths: Optional[npt.NDArray[np.float16]]
 
-def args_from_config(config: Dict|str, batch_size:int) -> Tuple[SimulationArgs, DataArgs]: ... # type: ignore
+def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, batch_size:int) -> Tuple[SimulationArgs, DataArgs]: ... # type: ignore
 
 def run_simulation(s: SimulationArgs, d: DataArgs) -> Tuple[FloatTensor, ByteTensor]: ... # type: ignore

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict
 from msgspec import Struct
 import numpy as np
 import numpy.typing as npt
@@ -19,5 +19,7 @@ class DataArgs(Struct):
     elements: npt.NDArray[np.float32]
     class_targets: npt.NDArray[np.int8]
     wavelengths: Optional[npt.NDArray[np.float16]]
+
+def args_from_config(config: Dict|str, batch_size:int) -> Tuple[SimulationArgs, DataArgs]: ... # type: ignore
 
 def run_simulation(s: SimulationArgs, d: DataArgs) -> Tuple[FloatTensor, ByteTensor]: ... # type: ignore

--- a/src/cover_class/utils.py
+++ b/src/cover_class/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict
-import yaml
+import yaml # type: ignore[import]
 
-def read_config(path:str) -> Dict: 
+def read_config(path: str|Dict) -> Dict: 
+    if isinstance(path, dict): return path
     with open(path, 'r') as f: return yaml.safe_load(f)

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -1,37 +1,38 @@
 import unittest
 from unittest.mock import patch
 import torch
+from torch.utils.data import DataLoader
 
 from cover_class.dataloader import OrchestratorDataset, OrchestratorDatasetArgs # type: ignore[import]
-from cover_class.simulation import SimulationArgs, DataArgs # type: ignore[import]
 
 RANDOM_SEED = 42
+
+def make_odsa(bsz, percent, s, d, sd, sl) -> OrchestratorDatasetArgs:
+    return OrchestratorDatasetArgs(
+        batch_size = bsz,
+        percent_static = percent,
+        sim_config_args = s,
+        sim_data_args = d,
+        static_data = sd,
+        static_labels = sl,
+    )
+
 
 class dataloaderTest(unittest.TestCase):
 
     def test_OrchestratorDatasetArgs(self):
         data = torch.randn(10, 5, dtype=torch.float32)
         labels = torch.randint(0, 3, (10,), dtype=torch.long)
-        
-        def make_odla(bsz, percent, s, d, sd, sl) -> OrchestratorDatasetArgs:
-            return OrchestratorDatasetArgs(
-                batch_size = bsz,
-                percent_static = percent,
-                sim_config_args = s,
-                sim_data_args = d,
-                static_data = sd,
-                static_labels = sl,
-            )
 
         with self.subTest("static_only_forces_100_percent_check"):
-            args = make_odla(10, 0., None, None, data, labels)
+            args = make_odsa(10, 0., None, None, data, labels)
             self.assertTrue(args._using_static)
             self.assertFalse(args._using_sim)
             self.assertEqual(args.percent_static, 100.0)
             self.assertTrue(torch.all(args._method_selection_idxs == 1))
 
         with self.subTest("simulation_only_forces_0_percent_check"):
-            args = make_odla(10, 100., object(), object(), None, None)
+            args = make_odsa(10, 100., object(), object(), None, None)
             self.assertFalse(args._using_static)
             self.assertTrue(args._using_sim)
             self.assertEqual(args.percent_static, 0.0)
@@ -39,7 +40,7 @@ class dataloaderTest(unittest.TestCase):
 
         with self.subTest("valid_simulation_and_static_data_check"):
             percent = 33.7
-            args = make_odla(10, percent, object(), object(), data, labels)
+            args = make_odsa(10, percent, object(), object(), data, labels)
             self.assertTrue(args._using_static)
             self.assertTrue(args._using_sim)
             self.assertEqual(args.percent_static, percent)
@@ -48,166 +49,113 @@ class dataloaderTest(unittest.TestCase):
 
         with self.subTest("percent_boundaries_check"):
             for percent in (0.0, 100.0):
-                args = make_odla(10, percent, object(), object(), data, labels)
+                args = make_odsa(10, percent, object(), object(), data, labels)
                 self.assertEqual(args.percent_static, percent)
                 self.assertEqual(int(args._method_selection_idxs.sum()), int(percent))
 
         with self.subTest("assertion_clauses_check"):
-            self.assertRaises(AssertionError, make_odla, 10, 0., None, None, None, None)
-            self.assertRaises(AssertionError, make_odla, 10, -.1, object(), object(), object(), object())
-            self.assertRaises(AssertionError, make_odla, 10, 100.1, object(), object(), object(), object())
+            self.assertRaises(AssertionError, make_odsa, 10, 0., None, None, None, None)
+            self.assertRaises(AssertionError, make_odsa, 10, -.1, object(), object(), object(), object())
+            self.assertRaises(AssertionError, make_odsa, 10, 100.1, object(), object(), object(), object())
 
-
-    # def test_dataloader(self):
-    #     # 1. test only static data
-    #     # 2. test only simulated data
-    #     # 3. test both mixed together
-    #     size = (10, 5)
-    #     torch.manual_seed(RANDOM_SEED)
-    #     static_data = torch.FloatTensor(torch.rand(size, dtype=torch.float32))
-    #     static_labels = torch.rand(size, dtype=torch.int8)
-    #     args = OrchestratorDatasetArgs(
-    #         batch_size = 3,
-    #         percent_static = 100.,
-    #         static_data = static_data,
-    #         static_labels = static_labels,
-    #     )
-    #     OrchestratorDataset()
 
     def test_OrchestratorDataset_simulated_only(self):
-        torch.manual_seed(RANDOM_SEED)
-        data = torch.ones((bsz, dims))
-        labels = torch.arange(bsz)
-
-        dummy_sim_cfg = object()
-        dummy_sim_data = object()
         bsz = 10
         dims = 5
 
-        def fake_run_simulation(_cfg, _data):
-            return data, labels
+        torch.manual_seed(RANDOM_SEED)
+        data = torch.ones((bsz, dims))
+        labels = torch.arange(bsz)
+        def mock_run_simulation(_cfg, _data): return data, labels
 
-        args = OrchestratorDatasetArgs(
-            batch_size=bsz,
-            percent_static=0.0,  # will be forced to 0 in __post_init__ anyway
-            sim_config_args=dummy_sim_cfg,
-            sim_data_args=dummy_sim_data,
-            static_data=None,
-            static_labels=None,
-        )
+        args = make_odsa(bsz, 0.0, object(), object(), None, None)
 
-        with patch("cover_class.dataloader.run_simulation", side_effect=fake_run_simulation):
-            dl = OrchestratorDataset(args)
+        with patch("cover_class.simulation.run_simulation", side_effect=mock_run_simulation):
+            ds = OrchestratorDataset(args)
+            dl = DataLoader(ds, batch_size=None)
 
+            i = 0
             for X, Y in dl:
-                self.assertTrue(dl.is_simulated_batch)
+                self.assertTrue(ds.is_simulated_batch)
                 self.assertIsInstance(X, torch.FloatTensor)
                 self.assertEqual(X.shape, (bsz, dims))
                 self.assertTrue(torch.allclose(X, data))
                 self.assertTrue(torch.equal(Y, labels))
+                self.assertEqual(ds.static_epoch, 0)
+                self.assertEqual(ds.static_epoch_step, 0)
+                self.assertEqual(ds.step, i+1)
+                
+                i += 1
+                if i == bsz*10: break
 
     def test_OrchestratorDataset_static_only(self):
-        """
-        When only static tensors are provided, batches should be drawn from the static set,
-        and an epoch reset should occur after consuming the dataset once.
-        This test also detects repeated identical batches if index progression doesn’t advance.
-        """
         torch.manual_seed(RANDOM_SEED)
 
-        N = 40
-        bs = 8
-        feat = 3
+        N, bsz, dims, epochs = 40, 10, 3, 5
 
-        # Build a labeled static dataset with unique rows per index to detect repetition
-        data = torch.arange(N * feat, dtype=torch.float32).reshape(N, feat)
+        data = torch.arange(N * dims, dtype=torch.float32).reshape(N, dims)
         labels = torch.arange(N, dtype=torch.long)
 
-        args = OrchestratorDatasetArgs(
-            batch_size=bs,
-            percent_static=100.0,  # will be forced to 100 in __post_init__
-            sim_config_args=None,
-            sim_data_args=None,
-            static_data=data,
-            static_labels=labels,
-        )
-        dl = OrchestratorDataset(args, shuffle=True)
+        args = make_odsa(bsz, 100.0, None, None, data, labels)
+        ods = OrchestratorDataset(args, shuffle=True)
+        dl = DataLoader(ods, batch_size=None)
 
-        with self.subTest("all-batches-static-and-cover-dataset-once"):
-            seen_rows = []
-            seen_labels = []
+        seen_rows = []
+        seen_labels = []
 
-            # Consume exactly N/bs batches (one epoch’s worth)
-            for _ in range(N // bs):
-                X, y = next(dl)
-                self.assertFalse(dl.is_simulated_batch)
-                self.assertEqual(X.shape, (bs, feat))
-                self.assertEqual(y.shape, (bs,))
+        i, t = 0, 0
+        for X, Y in dl:
+            i += 1; t += 1
+            if i == (N//bsz): i = 0
+            if t == (N//bsz)*epochs: break
+            self.assertFalse(ods.is_simulated_batch)
+            self.assertEqual(X.shape, (bsz, dims))
+            self.assertEqual(Y.shape, (bsz,))
+            self.assertEqual(ods.static_epoch_step, i)
+            self.assertEqual(ods.step, t)
+            if t <= (N//bsz):
                 seen_rows.append(X)
-                seen_labels.append(y)
+                seen_labels.append(Y)
+        self.assertEqual(ods.static_epoch, epochs)
 
-            X_all = torch.vstack(seen_rows)
-            y_all = torch.hstack(seen_labels)
+        X_all = torch.vstack(seen_rows)
+        y_all = torch.hstack(seen_labels)
 
-            # Expect to have seen N unique indices with no duplicates in one epoch
-            self.assertEqual(len(torch.unique(y_all)), N)
-            self.assertTrue(torch.equal(torch.sort(y_all).values, torch.arange(N)))
-
-            # After consuming an epoch, the loader should reset (epoch increment)
-            # NOTE: This assertion will FAIL if the internal step/epoch counters don’t advance.
-            self.assertGreaterEqual(dl.static_epoch, 1, msg="static_epoch did not advance after one full pass")
+        self.assertEqual(len(torch.unique(y_all)), N)
+        self.assertTrue(torch.equal(torch.sort(y_all).values, torch.arange(N)))
 
     def test_OrchestratorDataset_mixed_static_and_sim(self):
-        """
-        With both static tensors and sim args provided, the loader should produce
-        a mix of static and simulated batches following _method_selection_idxs
-        derived from percent_static.
-        """
+        bsz, dims = 10, 5
+        percent_static = 60.0
+
         torch.manual_seed(RANDOM_SEED)
+        static_data = torch.ones((bsz, dims))
+        static_labels = torch.arange(bsz)
+        sim_data = static_data + 3
+        sim_labels = static_labels + 3
+        def mock_run_simulation(_cfg, _data): return sim_data, sim_labels
 
-        N = 100
-        bs = 10
-        feat = 4
+        args = make_odsa(bsz, percent_static, object(), object(), static_data, static_labels)
 
-        data = torch.randn(N, feat)
-        labels = torch.arange(N, dtype=torch.long)
-
-        percent_static = 60.0  # expect exactly 60 static batches out of 100 steps
-
-        # Minimal stand-ins for sim args
-        dummy_sim_cfg = object()
-        dummy_sim_data = object()
-
-        def fake_run_simulation(_cfg, _data):
-            return torch.zeros(bs, feat), torch.full((bs,), -1, dtype=torch.long)
-
-        args = OrchestratorDatasetArgs(
-            batch_size=bs,
-            percent_static=percent_static,
-            sim_config_args=dummy_sim_cfg,
-            sim_data_args=dummy_sim_data,
-            static_data=data,
-            static_labels=labels,
-        )
-
-        with patch("cover_class.dataloader.run_simulation", side_effect=fake_run_simulation):
-            dl = OrchestratorDataset(args, shuffle=True)
+        with patch("cover_class.simulation.run_simulation", side_effect=mock_run_simulation):
+            ods = OrchestratorDataset(args, shuffle=True)
+            dl = DataLoader(ods, batch_size=None)
 
             static_count = 0
             sim_count = 0
-
-            # Consume 100 steps to align with the size of _method_selection_idxs
-            for _ in range(100):
-                X, y = next(dl)
-                if dl.is_simulated_batch:
+            i = 0
+            for X, Y in dl:
+                if ods.is_simulated_batch:
                     sim_count += 1
-                    # Simulated sentinel values
-                    self.assertTrue(torch.all(X == 0))
-                    self.assertTrue(torch.all(y == -1))
+                    self.assertTrue(torch.allclose(X, sim_data))
+                    self.assertTrue(torch.equal(Y, sim_labels))
                 else:
                     static_count += 1
-                    # Static batch shape checks
-                    self.assertEqual(X.shape, (bs, feat))
-                    self.assertEqual(y.shape, (bs,))
+                    self.assertTrue(torch.allclose(X, static_data))
+                    sorted, _ =  torch.sort(Y)
+                    self.assertTrue(torch.equal(sorted, static_labels))
+                i += 1
+                if i == 100: break
 
             self.assertEqual(static_count, int(percent_static))
             self.assertEqual(sim_count, 100 - int(percent_static))

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -1,19 +1,20 @@
 import unittest
+from unittest.mock import patch
 import torch
 
-from cover_class.dataloader import OrchestratorDataLoader, OrchestratorDataLoaderArgs # type: ignore[import]
+from cover_class.dataloader import OrchestratorDataset, OrchestratorDatasetArgs # type: ignore[import]
 from cover_class.simulation import SimulationArgs, DataArgs # type: ignore[import]
 
 RANDOM_SEED = 42
 
 class dataloaderTest(unittest.TestCase):
 
-    def test_OrchestratorDataLoaderArgs(self):
+    def test_OrchestratorDatasetArgs(self):
         data = torch.randn(10, 5, dtype=torch.float32)
         labels = torch.randint(0, 3, (10,), dtype=torch.long)
         
-        def make_odla(bsz, percent, s, d, sd, sl) -> OrchestratorDataLoaderArgs:
-            return OrchestratorDataLoaderArgs(
+        def make_odla(bsz, percent, s, d, sd, sl) -> OrchestratorDatasetArgs:
+            return OrchestratorDatasetArgs(
                 batch_size = bsz,
                 percent_static = percent,
                 sim_config_args = s,
@@ -65,10 +66,148 @@ class dataloaderTest(unittest.TestCase):
     #     torch.manual_seed(RANDOM_SEED)
     #     static_data = torch.FloatTensor(torch.rand(size, dtype=torch.float32))
     #     static_labels = torch.rand(size, dtype=torch.int8)
-    #     args = OrchestratorDataLoaderArgs(
+    #     args = OrchestratorDatasetArgs(
     #         batch_size = 3,
     #         percent_static = 100.,
     #         static_data = static_data,
     #         static_labels = static_labels,
     #     )
-    #     OrchestratorDataLoader()
+    #     OrchestratorDataset()
+
+    def test_OrchestratorDataset_simulated_only(self):
+        torch.manual_seed(RANDOM_SEED)
+        data = torch.ones((bsz, dims))
+        labels = torch.arange(bsz)
+
+        dummy_sim_cfg = object()
+        dummy_sim_data = object()
+        bsz = 10
+        dims = 5
+
+        def fake_run_simulation(_cfg, _data):
+            return data, labels
+
+        args = OrchestratorDatasetArgs(
+            batch_size=bsz,
+            percent_static=0.0,  # will be forced to 0 in __post_init__ anyway
+            sim_config_args=dummy_sim_cfg,
+            sim_data_args=dummy_sim_data,
+            static_data=None,
+            static_labels=None,
+        )
+
+        with patch("cover_class.dataloader.run_simulation", side_effect=fake_run_simulation):
+            dl = OrchestratorDataset(args)
+
+            for X, Y in dl:
+                self.assertTrue(dl.is_simulated_batch)
+                self.assertIsInstance(X, torch.FloatTensor)
+                self.assertEqual(X.shape, (bsz, dims))
+                self.assertTrue(torch.allclose(X, data))
+                self.assertTrue(torch.equal(Y, labels))
+
+    def test_OrchestratorDataset_static_only(self):
+        """
+        When only static tensors are provided, batches should be drawn from the static set,
+        and an epoch reset should occur after consuming the dataset once.
+        This test also detects repeated identical batches if index progression doesn’t advance.
+        """
+        torch.manual_seed(RANDOM_SEED)
+
+        N = 40
+        bs = 8
+        feat = 3
+
+        # Build a labeled static dataset with unique rows per index to detect repetition
+        data = torch.arange(N * feat, dtype=torch.float32).reshape(N, feat)
+        labels = torch.arange(N, dtype=torch.long)
+
+        args = OrchestratorDatasetArgs(
+            batch_size=bs,
+            percent_static=100.0,  # will be forced to 100 in __post_init__
+            sim_config_args=None,
+            sim_data_args=None,
+            static_data=data,
+            static_labels=labels,
+        )
+        dl = OrchestratorDataset(args, shuffle=True)
+
+        with self.subTest("all-batches-static-and-cover-dataset-once"):
+            seen_rows = []
+            seen_labels = []
+
+            # Consume exactly N/bs batches (one epoch’s worth)
+            for _ in range(N // bs):
+                X, y = next(dl)
+                self.assertFalse(dl.is_simulated_batch)
+                self.assertEqual(X.shape, (bs, feat))
+                self.assertEqual(y.shape, (bs,))
+                seen_rows.append(X)
+                seen_labels.append(y)
+
+            X_all = torch.vstack(seen_rows)
+            y_all = torch.hstack(seen_labels)
+
+            # Expect to have seen N unique indices with no duplicates in one epoch
+            self.assertEqual(len(torch.unique(y_all)), N)
+            self.assertTrue(torch.equal(torch.sort(y_all).values, torch.arange(N)))
+
+            # After consuming an epoch, the loader should reset (epoch increment)
+            # NOTE: This assertion will FAIL if the internal step/epoch counters don’t advance.
+            self.assertGreaterEqual(dl.static_epoch, 1, msg="static_epoch did not advance after one full pass")
+
+    def test_OrchestratorDataset_mixed_static_and_sim(self):
+        """
+        With both static tensors and sim args provided, the loader should produce
+        a mix of static and simulated batches following _method_selection_idxs
+        derived from percent_static.
+        """
+        torch.manual_seed(RANDOM_SEED)
+
+        N = 100
+        bs = 10
+        feat = 4
+
+        data = torch.randn(N, feat)
+        labels = torch.arange(N, dtype=torch.long)
+
+        percent_static = 60.0  # expect exactly 60 static batches out of 100 steps
+
+        # Minimal stand-ins for sim args
+        dummy_sim_cfg = object()
+        dummy_sim_data = object()
+
+        def fake_run_simulation(_cfg, _data):
+            return torch.zeros(bs, feat), torch.full((bs,), -1, dtype=torch.long)
+
+        args = OrchestratorDatasetArgs(
+            batch_size=bs,
+            percent_static=percent_static,
+            sim_config_args=dummy_sim_cfg,
+            sim_data_args=dummy_sim_data,
+            static_data=data,
+            static_labels=labels,
+        )
+
+        with patch("cover_class.dataloader.run_simulation", side_effect=fake_run_simulation):
+            dl = OrchestratorDataset(args, shuffle=True)
+
+            static_count = 0
+            sim_count = 0
+
+            # Consume 100 steps to align with the size of _method_selection_idxs
+            for _ in range(100):
+                X, y = next(dl)
+                if dl.is_simulated_batch:
+                    sim_count += 1
+                    # Simulated sentinel values
+                    self.assertTrue(torch.all(X == 0))
+                    self.assertTrue(torch.all(y == -1))
+                else:
+                    static_count += 1
+                    # Static batch shape checks
+                    self.assertEqual(X.shape, (bs, feat))
+                    self.assertEqual(y.shape, (bs,))
+
+            self.assertEqual(static_count, int(percent_static))
+            self.assertEqual(sim_count, 100 - int(percent_static))

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -1,0 +1,74 @@
+import unittest
+import torch
+
+from cover_class.dataloader import OrchestratorDataLoader, OrchestratorDataLoaderArgs # type: ignore[import]
+from cover_class.simulation import SimulationArgs, DataArgs # type: ignore[import]
+
+RANDOM_SEED = 42
+
+class dataloaderTest(unittest.TestCase):
+
+    def test_OrchestratorDataLoaderArgs(self):
+        data = torch.randn(10, 5, dtype=torch.float32)
+        labels = torch.randint(0, 3, (10,), dtype=torch.long)
+        
+        def make_odla(bsz, percent, s, d, sd, sl) -> OrchestratorDataLoaderArgs:
+            return OrchestratorDataLoaderArgs(
+                batch_size = bsz,
+                percent_static = percent,
+                sim_config_args = s,
+                sim_data_args = d,
+                static_data = sd,
+                static_labels = sl,
+            )
+
+        with self.subTest("static_only_forces_100_percent_check"):
+            args = make_odla(10, 0., None, None, data, labels)
+            self.assertTrue(args._using_static)
+            self.assertFalse(args._using_sim)
+            self.assertEqual(args.percent_static, 100.0)
+            self.assertTrue(torch.all(args._method_selection_idxs == 1))
+
+        with self.subTest("simulation_only_forces_0_percent_check"):
+            args = make_odla(10, 100., object(), object(), None, None)
+            self.assertFalse(args._using_static)
+            self.assertTrue(args._using_sim)
+            self.assertEqual(args.percent_static, 0.0)
+            self.assertTrue(torch.all(args._method_selection_idxs == 0))
+
+        with self.subTest("valid_simulation_and_static_data_check"):
+            percent = 33.7
+            args = make_odla(10, percent, object(), object(), data, labels)
+            self.assertTrue(args._using_static)
+            self.assertTrue(args._using_sim)
+            self.assertEqual(args.percent_static, percent)
+            self.assertTrue(torch.all(args._method_selection_idxs[:int(percent)] == 1))
+            self.assertTrue(torch.all(args._method_selection_idxs[int(percent):] == 0))
+
+        with self.subTest("percent_boundaries_check"):
+            for percent in (0.0, 100.0):
+                args = make_odla(10, percent, object(), object(), data, labels)
+                self.assertEqual(args.percent_static, percent)
+                self.assertEqual(int(args._method_selection_idxs.sum()), int(percent))
+
+        with self.subTest("assertion_clauses_check"):
+            self.assertRaises(AssertionError, make_odla, 10, 0., None, None, None, None)
+            self.assertRaises(AssertionError, make_odla, 10, -.1, object(), object(), object(), object())
+            self.assertRaises(AssertionError, make_odla, 10, 100.1, object(), object(), object(), object())
+
+
+    # def test_dataloader(self):
+    #     # 1. test only static data
+    #     # 2. test only simulated data
+    #     # 3. test both mixed together
+    #     size = (10, 5)
+    #     torch.manual_seed(RANDOM_SEED)
+    #     static_data = torch.FloatTensor(torch.rand(size, dtype=torch.float32))
+    #     static_labels = torch.rand(size, dtype=torch.int8)
+    #     args = OrchestratorDataLoaderArgs(
+    #         batch_size = 3,
+    #         percent_static = 100.,
+    #         static_data = static_data,
+    #         static_labels = static_labels,
+    #     )
+    #     OrchestratorDataLoader()


### PR DESCRIPTION
## Overview
This PR builds out the dataloader capability for providing both simulated or static data, or both. 

The main new components are:
1. `OrchestratorDatasetArgs`
      - This struct (class) defines the set of arguments that will be passed into the `OrchestratorDataset`.
      - The main function is that it defines if static data only, simulated data only, or both will be provided
2. `OrchestratorDataset`
      - This is an inherited class of the Pytorch `IterableDataset` so that it could function on a per-batch basis instead of on an individual datapoint level.
      - The policy is that either a simulated or static dataset will be provided at some incremental level.
      - The iterator does NOT stop as well. **It will be the caller's responsibility to terminate the iterator**
      - There are a number of stateful features for the static data batches:
            - `static_epoch`, `static_epoch_step`, `static_samples_seen`, `is_simulated_batch`
            - From these, one could then infer the simulated data info
3. `dataloader_from_config`
      - This function creates a Pytorch DataLoader with the `OrchestratorDataset` as the dataset generator, building the arguments from the config files and a set of 

1 small refactor:
- src/cover_class/utils.py `read_config`
     - This is added for the `dataloader_from_config` not reloading the config when it calls `args_from_config`

1 new stub:
- src/cover_class/simulation/simulate.py `args_from_config`
     - This is included as the `dataloader_from_config` needs to call it and receive the intended args. 

#### User's Notes
Example intended use case:
```
>>> old = OrchestratorDataset(args)
>>> dl = DataLoader(old, batch_size=None)
>>> # NOTE: The `batch_size` in the dataloader must be set to `None`
>>> for X, Y in dl:
>>>     ...
```
or
```
>>> my_config_path = '/my/path/config.yaml'
>>> dataloader: DataLoader = dataloader_from_config( # the DataLoader has the OrchestratorDataset generator
    my_config_path, 
    data_train, 
    labels_train,
    batch_size,
    shuffle
)
```

#### Misc. Notes
You will likely notice that the batch size is NOT a property of the config and needs to be passed through as a parameter. This is intentional. The reason being is that the batch size is a function of the model (training) hyperparameters and training process which requires its own study on the critical batch sizes, loss and gradient effects, etc. As such, it's much more appropriate to not include it here and allow the user to control that from their end so that way they could do a proper batch size study for their model.


## Related Tickets

## Testing
The testing conducted has been in the form of unit tests that I tried to make representative of the actual use cases that could arise. You could run these as well with `make test`

