### PR TITLE
Simulation dirichlet fraction return

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ dataloader, X_test, Y_test = setup_training_from_config(
 )
 ```
 
+To get the dirichlet fractions, after every iteration, check `dataloader.dataset.batch_dirichlet_fraction_store` for the fractions. (Assuming that `simulation.return_fractions` was set to `true` in dataloader.yml)
+
 ### Static Dataset Processing
 This is to demonstrate how to create a standardized set of HDF5 datasets for training.
 It gets the data matrix from a supported CSV format from either a VFS or downloaded through the network.

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -19,5 +19,6 @@ simulation:
   alpha_uniform_high: 10.
   white_noise: 0.0001
   noise_covariance_csv: example.csv
+  return_fractions: false
 dataloader:
   percent-static-data: 0.5

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -22,6 +22,7 @@ simulation:
   alpha_uniform_high: 10.
   white_noise: 0.0001
   noise_covariance_csv: example.csv
+  return_fractions: false
 subsample:
   test-fraction: 0.2
   selected-method: convex-hull
@@ -51,6 +52,5 @@ subsample:
     n_samples: 10
     hypercubes_per_dimension: 3
     samples_per_hypercube: 3
-  return_fractions: false
 dataloader:
   percent-static-data: 0.5

--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -47,7 +47,7 @@ class OrchestratorDataset(IterableDataset):
     >>> old = OrchestratorDataset(args)
     >>> dl = DataLoader(old, batch_size=None)
     >>> # NOTE: The `batch_size` in the dataloader must be set to `None`
-    >>> for X, Y in dl:
+    >>> for X, Y, f in dl:
     >>>     ...
     '''
     args: OrchestratorDatasetArgs
@@ -68,7 +68,7 @@ class OrchestratorDataset(IterableDataset):
         self.args = args; self.shuffle = shuffle
         if self.args._using_static: self.__shuffle__()
 
-    def __iter__(self) -> Iterator[Tuple[torch.FloatTensor, torch.Tensor]]:
+    def __iter__(self) -> Iterator[Tuple[torch.FloatTensor, torch.Tensor, Optional[torch.FloatTensor]]]:
         ''' This iterator does not stop '''
         while True:
             self.step += 1
@@ -82,7 +82,7 @@ class OrchestratorDataset(IterableDataset):
                 self.static_samples_seen += len(idx)
                 if end >= len(self.args.static_data)-1: # type: ignore
                     self.__reset__()
-                yield self.args.static_data[idx], self.args.static_labels[idx] # type: ignore
+                yield self.args.static_data[idx], self.args.static_labels[idx], None # type: ignore
 
             elif self.args._using_sim:
                 self.is_simulated_batch = True

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -17,6 +17,7 @@ class SimulationArgs(Struct):
     alpha_uniform_high: float
     white_noise: float
     noise_covariance: Optional[FloatTensor]
+    return_fractions: bool
 
     def to(self, device: torch.device):
         if self.noise_covariance is not None: 
@@ -35,7 +36,7 @@ class DataArgs(Struct):
 
 def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, batch_size:int) -> Tuple[SimulationArgs, DataArgs]:
     config = read_config(config)
-    sim_config = config['simulation']
+    sim_config:dict = config['simulation']
     n_classes = sum(map(bool, config['datasets'].values()))
     noise_cov = None
     if sim_config['noise_covariance_csv']:
@@ -52,7 +53,8 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         alpha_uniform_low = sim_config['alpha_uniform_low'],
         alpha_uniform_high = sim_config['alpha_uniform_high'],
         white_noise = sim_config['white_noise'],
-        noise_covariance = FloatTensor(torch.from_numpy(noise_cov).to(torch.float32)) if noise_cov is not None else None
+        noise_covariance = FloatTensor(torch.from_numpy(noise_cov).to(torch.float32)) if noise_cov is not None else None,
+        return_fractions=sim_config["return_fractions"],
     )
 
     d = DataArgs(

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -92,7 +92,12 @@ def run_simulation(
         )
 
         if sim_args.return_fractions:
-            return resulting_real_spectra, classes.long(), dirich_fractions # type: ignore[return-value]
+            fracs_by_class = get_fractions_by_class(
+                filtered_n_components_per_class,
+                classes,
+                dirich_fractions,
+            )
+            return resulting_real_spectra, classes.long(), fracs_by_class # type: ignore[return-value]
         return resulting_real_spectra, classes.long(), None # type: ignore[return-value]
 
 
@@ -288,10 +293,37 @@ def _6_add_noise(
     return noise.to(dtype=torch.float32)  # type: ignore[return-value]
 
 
-
 def make_positive_definite(A: Tensor, min_eigen=1e-8) -> FloatTensor:
     assert len(A.shape)==2, "A needs to be a 2D matrix"
     A = (A + A.T) * 0.5 # makes real, symmetric
     eigenvals, eigenvecs = torch.linalg.eigh(A)
     eigenvals = torch.clamp(eigenvals, min=min_eigen)
     return (eigenvecs * eigenvals.unsqueeze(-2)) @ eigenvecs.T
+
+
+def get_fractions_by_class(
+        filtered_n_components_per_class: ShortTensor, 
+        classes: CharTensor,
+        dirich_fractions: FloatTensor,
+
+    ) -> FloatTensor:
+    # Returns a (n_iter, n_classes) matrix of the sum of dirichlet constributions per class
+    
+    # first get the dirichlet fractions by number of components
+    R, N = filtered_n_components_per_class.shape
+    M = dirich_fractions.size(1)
+    ends = filtered_n_components_per_class.cumsum(1) # (R, N)
+    pos  = torch.arange(M, device=dirich_fractions.device).expand(R, M)
+    grp  = torch.searchsorted(ends, pos, right=True)
+    fmask = pos < ends[:, -1:]
+    summed_fracs = dirich_fractions.new_zeros(R, N)
+    summed_fracs.scatter_add_(1, grp.clamp_max(N-1), dirich_fractions * fmask)
+
+    # then assign each of those to a class (one-hot)
+    valid = classes >= 0
+    cls = classes.clamp_min(0)
+    num_classes = int(cls[valid].max().item()) + 1 if valid.any() else 0
+    result = summed_fracs.new_zeros(summed_fracs.size(0), num_classes)
+    result.scatter_add_(1, cls.to(dtype=torch.int32), summed_fracs * valid)
+
+    return result # type: ignore[return-value]

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -310,14 +310,14 @@ def get_fractions_by_class(
     # Returns a (n_iter, n_classes) matrix of the sum of dirichlet constributions per class
     
     # first get the dirichlet fractions by number of components
-    R, N = filtered_n_components_per_class.shape
-    M = dirich_fractions.size(1)
+    n_iters, n_classes_per_sim = filtered_n_components_per_class.shape
+    n_max_sim_comps = dirich_fractions.size(1)
     ends = filtered_n_components_per_class.cumsum(1) # (R, N)
-    pos  = torch.arange(M, device=dirich_fractions.device).expand(R, M)
-    grp  = torch.searchsorted(ends, pos, right=True)
+    pos = torch.arange(n_max_sim_comps, device=dirich_fractions.device).expand(n_iters, n_max_sim_comps)
+    grp = torch.searchsorted(ends, pos, right=True)
     fmask = pos < ends[:, -1:]
-    summed_fracs = dirich_fractions.new_zeros(R, N)
-    summed_fracs.scatter_add_(1, grp.clamp_max(N-1), dirich_fractions * fmask)
+    summed_fracs = dirich_fractions.new_zeros(n_iters, n_classes_per_sim)
+    summed_fracs.scatter_add_(1, grp.clamp_max(n_classes_per_sim-1), dirich_fractions * fmask)
 
     # then assign each of those to a class (one-hot)
     valid = classes >= 0

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -35,9 +35,10 @@ def reduce_between(mask: BoolTensor, cumsum_n_components: LongTensor) -> ShortTe
 def run_simulation(
         sim_args:  SimulationArgs, 
         data_args: DataArgs, 
+        return_fractions: bool = False,
         device:    Device = Device("cpu")
     
-    ) -> Tuple[FloatTensor, CharTensor]:
+    ) -> Tuple[FloatTensor, CharTensor, Optional[FloatTensor]]:
 
     sim_args.to(device)
     data_args.to(device)
@@ -91,7 +92,9 @@ def run_simulation(
             device
         )
 
-        return resulting_real_spectra, classes # type: ignore[return-value]
+        if return_fractions:
+            return resulting_real_spectra, classes, dirich_fractions # type: ignore[return-value]
+        return resulting_real_spectra, classes, None # type: ignore[return-value]
 
 
 def _0_init_simulation_state(

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -38,7 +38,7 @@ def run_simulation(
         return_fractions: bool = False,
         device:    Device = Device("cpu")
     
-    ) -> Tuple[FloatTensor, CharTensor, Optional[FloatTensor]]:
+    ) -> Tuple[FloatTensor, LongTensor, Optional[FloatTensor]]:
 
     sim_args.to(device)
     data_args.to(device)
@@ -93,8 +93,8 @@ def run_simulation(
         )
 
         if return_fractions:
-            return resulting_real_spectra, classes, dirich_fractions # type: ignore[return-value]
-        return resulting_real_spectra, classes, None # type: ignore[return-value]
+            return resulting_real_spectra, classes.long(), dirich_fractions # type: ignore[return-value]
+        return resulting_real_spectra, classes.long(), None # type: ignore[return-value]
 
 
 def _0_init_simulation_state(

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -35,7 +35,6 @@ def reduce_between(mask: BoolTensor, cumsum_n_components: LongTensor) -> ShortTe
 def run_simulation(
         sim_args:  SimulationArgs, 
         data_args: DataArgs, 
-        return_fractions: bool = False,
         device:    Device = Device("cpu")
     
     ) -> Tuple[FloatTensor, LongTensor, Optional[FloatTensor]]:
@@ -92,7 +91,7 @@ def run_simulation(
             device
         )
 
-        if return_fractions:
+        if sim_args.return_fractions:
             return resulting_real_spectra, classes.long(), dirich_fractions # type: ignore[return-value]
         return resulting_real_spectra, classes.long(), None # type: ignore[return-value]
 

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -183,3 +183,6 @@ class dataloaderTest(unittest.TestCase):
 
             self.assertEqual(static_count, int(percent_static*100))
             self.assertEqual(sim_count, 100 - int(percent_static*100))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -31,7 +31,8 @@ def new_sim_args() -> Tuple[SimulationArgs, DataArgs]:
         alpha_uniform_low = 0.,
         alpha_uniform_high = 0.,
         white_noise = 0.,
-        noise_covariance = None
+        noise_covariance = None,
+        return_fractions = False,
     ),
     None)
     # DataArgs(torch.tensor([.1, .2, .3]), torch.tensor([.1, .2, .3])))
@@ -85,7 +86,7 @@ class dataloaderTest(unittest.TestCase):
         data = torch.ones((bsz, dims))
         labels = torch.zeros((bsz,dims), dtype=torch.int32)
         sim_args, data_args = new_sim_args()
-        def mock_run_simulation(_cfg, _data): return data, labels
+        def mock_run_simulation(_cfg, _data): return data, labels, None
 
         args = make_odsa(bsz, 0.0, sim_args, object(), None, None)
 
@@ -155,7 +156,7 @@ class dataloaderTest(unittest.TestCase):
         static_labels = torch.ones(bsz, dtype=torch.long)
         sim_data = static_data + 3
         sim_labels = torch.ones(bsz, sim_args.n_classes, dtype=torch.long) + 2
-        def mock_run_simulation(_cfg, _data): return sim_data, sim_labels
+        def mock_run_simulation(_cfg, _data): return sim_data, sim_labels, None
         def mock_reset(): ...
 
         args = make_odsa(bsz, percent_static, sim_args, object(), static_data, static_labels)

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -66,7 +66,7 @@ class dataloaderTest(unittest.TestCase):
         torch.manual_seed(RANDOM_SEED)
         data = torch.ones((bsz, dims))
         labels = torch.arange(bsz)
-        def mock_run_simulation(_cfg, _data): return data, labels
+        def mock_run_simulation(_cfg, _data): return data, labels, None
 
         args = make_odsa(bsz, 0.0, object(), object(), None, None)
 
@@ -75,7 +75,7 @@ class dataloaderTest(unittest.TestCase):
             dl = DataLoader(ds, batch_size=None)
 
             i = 0
-            for X, Y in dl:
+            for X, Y, _ in dl:
                 self.assertTrue(ds.is_simulated_batch)
                 self.assertIsInstance(X, torch.FloatTensor)
                 self.assertEqual(X.shape, (bsz, dims))
@@ -104,7 +104,7 @@ class dataloaderTest(unittest.TestCase):
         seen_labels = []
 
         i, t = 0, 0
-        for X, Y in dl:
+        for X, Y, _ in dl:
             i += 1; t += 1
             if i == (N//bsz): i = 0
             if t == (N//bsz)*epochs: break
@@ -133,7 +133,7 @@ class dataloaderTest(unittest.TestCase):
         static_labels = torch.arange(bsz)
         sim_data = static_data + 3
         sim_labels = static_labels + 3
-        def mock_run_simulation(_cfg, _data): return sim_data, sim_labels
+        def mock_run_simulation(_cfg, _data): return sim_data, sim_labels, None
 
         args = make_odsa(bsz, percent_static, object(), object(), static_data, static_labels)
 
@@ -144,7 +144,7 @@ class dataloaderTest(unittest.TestCase):
             static_count = 0
             sim_count = 0
             i = 0
-            for X, Y in dl:
+            for X, Y, _ in dl:
                 if ods.is_simulated_batch:
                     sim_count += 1
                     self.assertTrue(torch.allclose(X, sim_data))

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -66,7 +66,7 @@ class dataloaderTest(unittest.TestCase):
         torch.manual_seed(RANDOM_SEED)
         data = torch.ones((bsz, dims))
         labels = torch.arange(bsz)
-        def mock_run_simulation(_cfg, _data): return data, labels, None
+        def mock_run_simulation(_cfg, _data): return data, labels
 
         args = make_odsa(bsz, 0.0, object(), object(), None, None)
 
@@ -75,7 +75,7 @@ class dataloaderTest(unittest.TestCase):
             dl = DataLoader(ds, batch_size=None)
 
             i = 0
-            for X, Y, _ in dl:
+            for X, Y in dl:
                 self.assertTrue(ds.is_simulated_batch)
                 self.assertIsInstance(X, torch.FloatTensor)
                 self.assertEqual(X.shape, (bsz, dims))
@@ -104,7 +104,7 @@ class dataloaderTest(unittest.TestCase):
         seen_labels = []
 
         i, t = 0, 0
-        for X, Y, _ in dl:
+        for X, Y in dl:
             i += 1; t += 1
             if i == (N//bsz): i = 0
             if t == (N//bsz)*epochs: break
@@ -133,7 +133,7 @@ class dataloaderTest(unittest.TestCase):
         static_labels = torch.arange(bsz)
         sim_data = static_data + 3
         sim_labels = static_labels + 3
-        def mock_run_simulation(_cfg, _data): return sim_data, sim_labels, None
+        def mock_run_simulation(_cfg, _data): return sim_data, sim_labels
 
         args = make_odsa(bsz, percent_static, object(), object(), static_data, static_labels)
 
@@ -144,7 +144,7 @@ class dataloaderTest(unittest.TestCase):
             static_count = 0
             sim_count = 0
             i = 0
-            for X, Y, _ in dl:
+            for X, Y in dl:
                 if ods.is_simulated_batch:
                     sim_count += 1
                     self.assertTrue(torch.allclose(X, sim_data))

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -19,7 +19,8 @@ def new_SimulationArgs() -> SimulationArgs:
         alpha_uniform_low = 0.,
         alpha_uniform_high = 0.,
         white_noise = 0.,
-        noise_covariance = None
+        noise_covariance = None,
+        return_fractions = False,
     )
 
 
@@ -215,6 +216,7 @@ class simulationTest(unittest.TestCase):
                 alpha_uniform_high=0.0,
                 white_noise=0.0,
                 noise_covariance=None,
+                return_fractions=False,
             )
 
             data_args = DataArgs(
@@ -318,6 +320,7 @@ class simulationTest(unittest.TestCase):
                 alpha_uniform_high=0.0,
                 white_noise=123.45,
                 noise_covariance=cov,
+                return_fractions=False,
             )
             data_args = DataArgs(torch.ones((120,N), dtype=torch.float32), torch.tensor(list(range(10))*12))
 

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -343,7 +343,38 @@ class simulationTest(unittest.TestCase):
             self.assertEqual(obtained_wavelength_dim, data_args.real_spectra.shape[1])
             self.assertEqual(obtained_n_iters, sim_args.n_iters)
 
+    def test_get_fractions_by_class(self):
+        filtered_n_components_per_class = torch.tensor(
+            [[1, 0, 1],
+             [0, 1, 2]], dtype=torch.int16
+        )
 
+        classes = torch.tensor(
+            [[2, -1, 0],
+             [1, 2, 0]], dtype=torch.int8
+        )
+
+        dirich_fractions = torch.tensor(
+            [[0.1, 0.2, 0.3, 0.4, 0.5],
+             [1.0, 2.0, 3.0, 4.0, 5.0]],
+            dtype=torch.float32
+        )
+
+        expected = torch.tensor(
+            [[0.2, 0.0, 0.1],
+             [5.0, 0.0, 1.0]],
+            dtype=torch.float32
+        )
+
+        out = simulate.get_fractions_by_class(
+            filtered_n_components_per_class,
+            classes,
+            dirich_fractions
+        )
+
+        torch.testing.assert_close(out, expected, rtol=0, atol=1e-7)
 
 if __name__ == "__main__":
-    unittest.main()
+    # unittest.main()
+    s = simulationTest()
+    s.test_get_fractions_by_class()


### PR DESCRIPTION
## Overview
This PR adds in the functionality for providing the dirichlet fractions as an option for the simulated data.

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/16

## Testing
run `make test` on the regression tests
The additional unit test was for manual verification of functionality. 