### PR TITLE
Fixed Regression Tests

### DIFF
--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -30,11 +30,11 @@ class OrchestratorDatasetArgs(Struct):
         self._using_static = (self.static_labels is not None) and (self.static_data is not None)
         self._using_sim = (self.sim_config_args is not None) and (self.sim_data_args is not None)
         assert self._using_static or self._using_sim, "Need to provide either simulation or static data arguments"
-        if self._using_static and not self._using_sim: self.percent_static = 100.
+        if self._using_static and not self._using_sim: self.percent_static = 1.00
         elif not self._using_static: self.percent_static = 0.
-        assert (self.percent_static is not None) and (0. <= self.percent_static <= 100.), "'percent_static' needs to be between [0, 100]"
+        assert (self.percent_static is not None) and (0. <= self.percent_static <= 1.00), "'percent_static' needs to be between [0, 1.]"
 
-        self.num_classes = self.sim_config_args.n_classes if self.sim_config_args.n_classes else len(torch.unique(self.static_labels))
+        self.num_classes = self.sim_config_args.n_classes if self._using_sim else len(torch.unique(self.static_labels))
 
         self._method_selection_idxs[:int(self.percent_static*100)] = 1
         self._shuffle_method_selection_idxs()

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -131,7 +131,7 @@ class dataloaderTest(unittest.TestCase):
             if t == (N//bsz)*epochs: break
             self.assertFalse(ods.is_simulated_batch)
             self.assertEqual(X.shape, (bsz, dims))
-            self.assertEqual(Y.shape, (bsz,))
+            self.assertEqual(Y.shape, (bsz, N))
             self.assertEqual(ods.static_epoch_step, i)
             self.assertEqual(ods.step, t)
             if t <= (N//bsz):
@@ -140,26 +140,28 @@ class dataloaderTest(unittest.TestCase):
         self.assertEqual(ods.static_epoch, epochs)
 
         X_all = torch.vstack(seen_rows)
-        y_all = torch.hstack(seen_labels)
+        y_all = torch.vstack(seen_labels)
 
-        self.assertEqual(len(torch.unique(y_all)), N)
-        self.assertTrue(torch.equal(torch.sort(y_all).values, torch.arange(N)))
+        self.assertEqual(y_all.sum(), N) # test the sum for the one-hot encoding
+        self.assertTrue(torch.equal(y_all.sum(1), torch.ones(N)))
 
     def test_OrchestratorDataset_mixed_static_and_sim(self):
         bsz, dims = 10, 5
-        percent_static = 60.0
+        percent_static = 0.60
+        sim_args, _ = new_sim_args()
 
         torch.manual_seed(RANDOM_SEED)
         static_data = torch.ones((bsz, dims))
-        static_labels = torch.arange(bsz)
+        static_labels = torch.ones(bsz, dtype=torch.long)
         sim_data = static_data + 3
-        sim_labels = static_labels + 3
+        sim_labels = torch.ones(bsz, sim_args.n_classes, dtype=torch.long) + 2
         def mock_run_simulation(_cfg, _data): return sim_data, sim_labels
+        def mock_reset(): ...
 
-        sim_args, data_args = new_sim_args()
-        args = make_odsa(bsz, percent_static, sim_args, data_args, static_data, static_labels)
+        args = make_odsa(bsz, percent_static, sim_args, object(), static_data, static_labels)
 
-        with patch("cover_class.simulation.run_simulation", side_effect=mock_run_simulation):
+        with patch("cover_class.simulation.run_simulation", side_effect=mock_run_simulation), \
+            patch("cover_class.dataloader.OrchestratorDataset.__reset__", side_effect=mock_reset):
             ods = OrchestratorDataset(args, shuffle=True)
             dl = DataLoader(ods, batch_size=None)
 
@@ -170,18 +172,14 @@ class dataloaderTest(unittest.TestCase):
                 if ods.is_simulated_batch:
                     sim_count += 1
                     self.assertTrue(torch.allclose(X, sim_data))
-                    self.assertTrue(torch.equal(Y, sim_labels))
+                    self.assertTrue(torch.equal(Y[:, sim_labels[0, 0]], torch.ones(len(Y))))
                 else:
                     static_count += 1
+                    dl.dataset.static_epoch_step = 0
                     self.assertTrue(torch.allclose(X, static_data))
-                    sorted, _ =  torch.sort(Y)
-                    self.assertTrue(torch.equal(sorted, static_labels))
+                    self.assertTrue(torch.equal(Y[:, 1], static_labels))
                 i += 1
                 if i == 100: break
 
-            self.assertEqual(static_count, int(percent_static))
-            self.assertEqual(sim_count, 100 - int(percent_static))
-
-if __name__ == '__main__':
-    d = dataloaderTest()
-    d.test_OrchestratorDataset_static_only()
+            self.assertEqual(static_count, int(percent_static*100))
+            self.assertEqual(sim_count, 100 - int(percent_static*100))

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -1,9 +1,11 @@
+from typing import Tuple
 import unittest
 from unittest.mock import patch
 import torch
 from torch.utils.data import DataLoader
 
 from cover_class.dataloader import OrchestratorDataset, OrchestratorDatasetArgs # type: ignore[import]
+from cover_class.simulation import SimulationArgs, DataArgs
 
 RANDOM_SEED = 42
 
@@ -17,46 +19,62 @@ def make_odsa(bsz, percent, s, d, sd, sl) -> OrchestratorDatasetArgs:
         static_labels = sl,
     )
 
+def new_sim_args() -> Tuple[SimulationArgs, DataArgs]:
+    return (
+    SimulationArgs(
+        n_iters = 100,
+        n_classes_in_subsets = 5,
+        n_classes = 10,
+        n_components = list(range(10)),
+        min_frac = 0.,
+        alpha = None,
+        alpha_uniform_low = 0.,
+        alpha_uniform_high = 0.,
+        white_noise = 0.,
+        noise_covariance = None
+    ),
+    None)
+    # DataArgs(torch.tensor([.1, .2, .3]), torch.tensor([.1, .2, .3])))
 
 class dataloaderTest(unittest.TestCase):
 
     def test_OrchestratorDatasetArgs(self):
         data = torch.randn(10, 5, dtype=torch.float32)
         labels = torch.randint(0, 3, (10,), dtype=torch.long)
+        sim_args, data_args = new_sim_args()
 
         with self.subTest("static_only_forces_100_percent_check"):
-            args = make_odsa(10, 0., None, None, data, labels)
+            args = make_odsa(10, 0., sim_args, data_args, data, labels)
             self.assertTrue(args._using_static)
             self.assertFalse(args._using_sim)
-            self.assertEqual(args.percent_static, 100.0)
+            self.assertEqual(args.percent_static, 1.00)
             self.assertTrue(torch.all(args._method_selection_idxs == 1))
 
         with self.subTest("simulation_only_forces_0_percent_check"):
-            args = make_odsa(10, 100., object(), object(), None, None)
+            args = make_odsa(10, 1.00, sim_args, object(), None, None)
             self.assertFalse(args._using_static)
             self.assertTrue(args._using_sim)
             self.assertEqual(args.percent_static, 0.0)
             self.assertTrue(torch.all(args._method_selection_idxs == 0))
 
         with self.subTest("valid_simulation_and_static_data_check"):
-            percent = 33.7
-            args = make_odsa(10, percent, object(), object(), data, labels)
+            percent = .337
+            args = make_odsa(10, percent, sim_args, object(), data, labels)
             self.assertTrue(args._using_static)
             self.assertTrue(args._using_sim)
             self.assertEqual(args.percent_static, percent)
-            self.assertTrue(torch.all(args._method_selection_idxs[:int(percent)] == 1))
-            self.assertTrue(torch.all(args._method_selection_idxs[int(percent):] == 0))
+            self.assertEqual(int(args._method_selection_idxs.sum()), int(percent*100))
 
         with self.subTest("percent_boundaries_check"):
-            for percent in (0.0, 100.0):
-                args = make_odsa(10, percent, object(), object(), data, labels)
+            for percent in (0.0, 1.00):
+                args = make_odsa(10, percent, sim_args, object(), data, labels)
                 self.assertEqual(args.percent_static, percent)
-                self.assertEqual(int(args._method_selection_idxs.sum()), int(percent))
+                self.assertEqual(int(args._method_selection_idxs.sum()), int(percent*100))
 
         with self.subTest("assertion_clauses_check"):
             self.assertRaises(AssertionError, make_odsa, 10, 0., None, None, None, None)
-            self.assertRaises(AssertionError, make_odsa, 10, -.1, object(), object(), object(), object())
-            self.assertRaises(AssertionError, make_odsa, 10, 100.1, object(), object(), object(), object())
+            self.assertRaises(AssertionError, make_odsa, 10, -.1, sim_args, object(), object(), object())
+            self.assertRaises(AssertionError, make_odsa, 10, 1.01, sim_args, object(), object(), object())
 
 
     def test_OrchestratorDataset_simulated_only(self):
@@ -65,10 +83,11 @@ class dataloaderTest(unittest.TestCase):
 
         torch.manual_seed(RANDOM_SEED)
         data = torch.ones((bsz, dims))
-        labels = torch.arange(bsz)
+        labels = torch.zeros((bsz,dims), dtype=torch.int32)
+        sim_args, data_args = new_sim_args()
         def mock_run_simulation(_cfg, _data): return data, labels
 
-        args = make_odsa(bsz, 0.0, object(), object(), None, None)
+        args = make_odsa(bsz, 0.0, sim_args, object(), None, None)
 
         with patch("cover_class.simulation.run_simulation", side_effect=mock_run_simulation):
             ds = OrchestratorDataset(args)
@@ -80,7 +99,8 @@ class dataloaderTest(unittest.TestCase):
                 self.assertIsInstance(X, torch.FloatTensor)
                 self.assertEqual(X.shape, (bsz, dims))
                 self.assertTrue(torch.allclose(X, data))
-                self.assertTrue(torch.equal(Y, labels))
+                self.assertTrue(torch.all(Y[:, 0] == 1)) # testing the labels this way since they're one-hot
+                self.assertTrue(torch.all(Y[:, 1:] == 0))
                 self.assertEqual(ds.static_epoch, 0)
                 self.assertEqual(ds.static_epoch_step, 0)
                 self.assertEqual(ds.step, i+1)
@@ -96,6 +116,7 @@ class dataloaderTest(unittest.TestCase):
         data = torch.arange(N * dims, dtype=torch.float32).reshape(N, dims)
         labels = torch.arange(N, dtype=torch.long)
 
+        # sim_args, data_args = new_sim_args()
         args = make_odsa(bsz, 100.0, None, None, data, labels)
         ods = OrchestratorDataset(args, shuffle=True)
         dl = DataLoader(ods, batch_size=None)
@@ -135,7 +156,8 @@ class dataloaderTest(unittest.TestCase):
         sim_labels = static_labels + 3
         def mock_run_simulation(_cfg, _data): return sim_data, sim_labels
 
-        args = make_odsa(bsz, percent_static, object(), object(), static_data, static_labels)
+        sim_args, data_args = new_sim_args()
+        args = make_odsa(bsz, percent_static, sim_args, data_args, static_data, static_labels)
 
         with patch("cover_class.simulation.run_simulation", side_effect=mock_run_simulation):
             ods = OrchestratorDataset(args, shuffle=True)
@@ -159,3 +181,7 @@ class dataloaderTest(unittest.TestCase):
 
             self.assertEqual(static_count, int(percent_static))
             self.assertEqual(sim_count, 100 - int(percent_static))
+
+if __name__ == '__main__':
+    d = dataloaderTest()
+    d.test_OrchestratorDataset_static_only()

--- a/tests/static/retrieval_test.py
+++ b/tests/static/retrieval_test.py
@@ -39,7 +39,7 @@ class retrievalTest(unittest.TestCase):
                 patch.object(Path, "exists"), \
                 patch(f"{MODULE}.vfs_csv", return_value=(target_wl, data)) as mock_vfs, \
                 patch(f"{MODULE}.download", return_value=(target_wl, data)) as mock_dl, \
-                patch(f"{MODULE}.interior_interpolation",return_value=interp_return) as mock_interp, \
+                patch(f"{MODULE}.interior_interpolation",return_value=(interp_return, target_wl)) as mock_interp, \
                 patch(f"{MODULE}.make_hdf5", return_value=f"{config['datasets']['output-directory']}/out.hdf5") as mock_h5:
                 
                 retrieval.generate_hdf5_from_config("dummy_config_path.yaml")

--- a/tests/subsample/forward_pipeline_test.py
+++ b/tests/subsample/forward_pipeline_test.py
@@ -35,7 +35,10 @@ class subsampleTest(unittest.TestCase):
             self.assertDictEqual(config['subsample'][t], call_args.kwargs) # type: ignore 
         list(map(check_args, {'convex-hull':cv_mock, 'kmeans':km_mock, 'kmedoids':kmed_mock, 'lhs':lhs_mock}.items()))
 
-        self.assertRaises(ValueError, check_args, ('fail', cv_mock))
+        # test that any other value returns all data
+        config['subsample']['selected-method'] = ''
+        result = subsample_from_config('/path', data)
+        torch.testing.assert_close(torch.from_numpy(data).to(torch.float32), result)
 
     def test_train_test_split(self):
         frac = 0.2
@@ -61,7 +64,7 @@ class subsampleTest(unittest.TestCase):
         expected = torch.tensor([[0, 3],
                                  [5, 8]], dtype=torch.float32)
 
-        self.assertTrue(torch.equal(result, expected))
+        np.testing.assert_array_equal(result, expected)
         self.assertEqual(result.shape, expected.shape)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Overview
This PR is to fix the regression tests that were broken when a set of PRs were merged:
https://github.com/emit-sds/cover-class/pull/22
https://github.com/emit-sds/cover-class/pull/20

This PR has minor changes to the dataloader, but most of the changes should be just on making sure the unit tests are correct and are passing.

## Related Tickets

## Testing
Run `make test` now, and all the issues should be resolved.