### PR TITLE
Edge Correction

### DIFF
--- a/src/cover_class/config/static.yml
+++ b/src/cover_class/config/static.yml
@@ -22,3 +22,5 @@ datasets:
     water:
       - http:example.com
       - /some/path
+left-edge-correction: 
+  - /some/path/to/hdf5: [100, 115, 200]

--- a/src/cover_class/static/preprocessor.py
+++ b/src/cover_class/static/preprocessor.py
@@ -29,7 +29,7 @@ def left_edge_scale(
     As such, there will be cumulaive scaling of the left-portion of the data matrix until the 
     edges are all sequentially processed/corrected. 
     """
-    for edge in left_edges:
+    for edge in sorted(left_edges):
         denom = np.where(data_matrix[:, edge] == 0, 1e-8, data_matrix[:, edge]) # division by 0 protection
         scaling_factors = data_matrix[:, edge+1] / denom
         data_matrix[:, :edge+1] *= scaling_factors[:, np.newaxis]

--- a/src/cover_class/static/preprocessor.py
+++ b/src/cover_class/static/preprocessor.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, List
 from torch import FloatTensor, Tensor
 import torch
 from numpy.typing import NDArray
@@ -19,3 +19,17 @@ def interior_interpolation(
 
 def convolve(data_matrix:FloatTensor) -> FloatTensor: ... # type: ignore 
 
+def left_edge_scale(
+        data_matrix: NDArray[np.float32],
+        left_edges: List[int]
+    ) -> None:
+    """
+    This function takes in the data matrix and the left edges of the edge discontinuity. 
+    It then scales the left side of the spectra to be on the same magnitude.
+    As such, there will be cumulaive scaling of the left-portion of the data matrix until the 
+    edges are all sequentially processed/corrected. 
+    """
+    for edge in left_edges:
+        denom = np.where(data_matrix[:, edge] == 0, 1e-8, data_matrix[:, edge]) # division by 0 protection
+        scaling_factors = data_matrix[:, edge+1] / denom
+        data_matrix[:, :edge+1] *= scaling_factors[:, np.newaxis]

--- a/src/cover_class/static/preprocessor.py
+++ b/src/cover_class/static/preprocessor.py
@@ -26,7 +26,7 @@ def left_edge_scale(
     """
     This function takes in the data matrix and the left edges of the edge discontinuity. 
     It then scales the left side of the spectra to be on the same magnitude.
-    As such, there will be cumulaive scaling of the left-portion of the data matrix until the 
+    As such, there will be cumulative scaling of the left-portion of the data matrix until the 
     edges are all sequentially processed/corrected. 
     """
     for edge in sorted(left_edges):

--- a/src/cover_class/static/retrieval.py
+++ b/src/cover_class/static/retrieval.py
@@ -9,7 +9,7 @@ from io import BytesIO
 import requests # type: ignore[import]
 
 from cover_class.utils import read_config
-from cover_class.static.preprocessor import interior_interpolation
+from cover_class.static.preprocessor import interior_interpolation, left_edge_scale
 
 
 def download(uri: str) -> Tuple[NDArray[np.float32], NDArray[np.float32]]:
@@ -85,13 +85,18 @@ def generate_hdf5_from_config(config_path:str) -> None:
     ds = config['datasets']
     outdir = ds['output-directory']
     assert Path(outdir).is_dir(), f"'output-directory': {outdir} is not a directory"
+    edges = config.get('left-edge-correction', dict({}))
 
     for d in (ds_classes := ds['classes']):
         if ds_classes[d] == None: continue
         for location in ds_classes[d]:
-            # 1. get the wavelength and spectra from the locations
+            # 1a. get the wavelength and spectra from the locations
             if Path(location).is_file(): file_wavelengths, spectra = vfs_csv(location)
             else: file_wavelengths, spectra = download(location)
+
+            # [Optional] 1b. correct for the left edges
+            if d in edges:
+                left_edge_scale(spectra, edges[d])
 
             # 2. interpolate the wavelengths
             spectra = spectra[~np.isnan(spectra).any(axis=1)]

--- a/src/cover_class/static/retrieval.py
+++ b/src/cover_class/static/retrieval.py
@@ -95,8 +95,8 @@ def generate_hdf5_from_config(config_path:str) -> None:
             else: file_wavelengths, spectra = download(location)
 
             # [Optional] 1b. correct for the left edges
-            if d in edges:
-                left_edge_scale(spectra, edges[d])
+            if location in edges:
+                left_edge_scale(spectra, edges[location])
 
             # 2. interpolate the wavelengths
             spectra = spectra[~np.isnan(spectra).any(axis=1)]

--- a/tests/static/retrieval_test.py
+++ b/tests/static/retrieval_test.py
@@ -6,6 +6,7 @@ import pandas as pd # type: ignore[import]
 import torch
 import io
 import contextlib
+from copy import deepcopy
 
 from cover_class.static import retrieval # type: ignore[import]
 MODULE = "cover_class.static.retrieval"
@@ -95,6 +96,28 @@ class retrievalTest(unittest.TestCase):
         np.testing.assert_allclose(wl, wls)
         np.testing.assert_allclose(sp, spectra)
 
+    def test_left_edge_correction(self):
+        data = np.array([
+            [1.0, 2.0, 4.0, 8.0],
+            [2.0, 4.0, 8.0, 16.0],
+        ], dtype=np.float32)
+        d0 = deepcopy(data)
+
+        left_edges = [1]
+        expected = np.array([
+            [2.0, 4.0, 4.0, 8.0],
+            [4.0, 8.0, 8.0, 16.0],
+        ], dtype=np.float32)
+        retrieval.left_edge_scale(d0, left_edges)
+        np.testing.assert_allclose(d0, expected, rtol=1e-6)
+
+        left_edges = [1,2]
+        expected = np.array([
+            [4.0, 8.0, 8.0, 8.0],
+            [8.0, 16.0, 16.0, 16.0],
+        ], dtype=np.float32)
+        retrieval.left_edge_scale(data, left_edges)
+        np.testing.assert_allclose(data, expected, rtol=1e-6)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/static/retrieval_test.py
+++ b/tests/static/retrieval_test.py
@@ -102,6 +102,7 @@ class retrievalTest(unittest.TestCase):
             [2.0, 4.0, 8.0, 16.0],
         ], dtype=np.float32)
         d0 = deepcopy(data)
+        d1 = deepcopy(data)
 
         left_edges = [1]
         expected = np.array([
@@ -116,6 +117,11 @@ class retrievalTest(unittest.TestCase):
             [4.0, 8.0, 8.0, 8.0],
             [8.0, 16.0, 16.0, 16.0],
         ], dtype=np.float32)
+        retrieval.left_edge_scale(d1, left_edges)
+        np.testing.assert_allclose(d1, expected, rtol=1e-6)
+        
+        # test out of order indices
+        left_edges = [2, 1]
         retrieval.left_edge_scale(data, left_edges)
         np.testing.assert_allclose(data, expected, rtol=1e-6)
 


### PR DESCRIPTION
## Overview
This PR is to add in the edge correction according to [Francisco's code](https://github.com/fotxoa-geo/terraspec/blob/research/simulation/clean_libraries.py#L243). 

It's fairly straight forward. The `static.yml` file defines a new field for edge correction where there's a new key-value pair that's the "name-of-file": [list, of, left, edge, indices]. Then during the static processing portion, it'll perform an in-place correction of the magnitudes of the edge discontinuities. 

To note: the edge correction will adjust the preceding LEFT side of the edge discontinuity. AND moreover, the preceding left spectra magnitudes will be cumulatively scaled as there are more edges to correct.

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/29

## Testing
Regression tested + additional unit tests. Run `make test` to verify.
```
(emit-fc) makiper@MT-400290 cover-class % make test
python3 -m unittest discover tests -p '*_test.py'
.......................
----------------------------------------------------------------------
Ran 23 tests in 0.499s

OK
```