### PR TITLE
Resolve Torch Warning

### DIFF
--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -313,7 +313,7 @@ def get_fractions_by_class(
     n_iters, n_classes_per_sim = filtered_n_components_per_class.shape
     n_max_sim_comps = dirich_fractions.size(1)
     ends = filtered_n_components_per_class.cumsum(1) # (R, N)
-    pos = torch.arange(n_max_sim_comps, device=dirich_fractions.device).expand(n_iters, n_max_sim_comps)
+    pos = torch.arange(n_max_sim_comps, device=dirich_fractions.device).unsqueeze(0).repeat(n_iters, 1)
     grp = torch.searchsorted(ends, pos, right=True)
     fmask = pos < ends[:, -1:]
     summed_fracs = dirich_fractions.new_zeros(n_iters, n_classes_per_sim)

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -51,7 +51,7 @@ def setup_training_from_config(
     odl = dataloader_from_config(
         config, 
         FloatTensor(train_spectra),
-        train_labels,
+        LongTensor(train_labels.to(dtype=torch.long)),
         batch_size,
         shuffle,
     )        


### PR DESCRIPTION
## Overview
This PR resolves a PyTorch warning about needing to re-allocate non-contiguous vectors, and a mypy lint warning. There is no functional changes I will be merging this without needing reviewers.

## Testing
Regression testing as there is no functional changes.