### PR TITLE
Manual Seeding

### DIFF
--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Optional
 from torch import FloatTensor, Tensor, LongTensor
 from torch.utils.data import DataLoader
 import torch
@@ -6,7 +6,7 @@ import h5py # type: ignore[import]
 from copy import deepcopy
 
 from cover_class.dataloader import dataloader_from_config, OrchestratorDataset
-from cover_class.utils import read_config
+from cover_class.utils import read_config, seed as sseed
 from cover_class.subsample import subsample_from_config, train_test_split, drop_bad_bands
 from cover_class.simulation import run_simulation, SimulationArgs
 
@@ -14,12 +14,15 @@ def setup_training_from_config(
         config: str|Dict, 
         batch_size: int,
         shuffle: bool = True,
+        seed: Optional[int] = None,
     ) -> Tuple[DataLoader, FloatTensor, Tensor]:
     """
     :param: simulated_test_set_n_rows = 0 means don't return a simulated set
 
     Returns: A tuple of the training dataloader, the test data matrix, and test labels
     """
+    if seed is not None:
+        sseed(seed)
 
     train_spectra, train_labels, test_spectra, test_labels = Tensor(), Tensor(), Tensor(), Tensor()
 

--- a/src/cover_class/utils.py
+++ b/src/cover_class/utils.py
@@ -18,4 +18,5 @@ def seed(s:int):
     torch.use_deterministic_algorithms(True)
     torch.backends.cudnn.benchmark = False
     torch.backends.cudnn.deterministic = True
-    torch.mps.manual_seed(s)
+    if hasattr(torch, "mps") and hasattr(torch.mps, "manual_seed") and torch.backends.mps.is_available():
+        torch.mps.manual_seed(s)

--- a/src/cover_class/utils.py
+++ b/src/cover_class/utils.py
@@ -1,6 +1,21 @@
 from typing import Dict
 import yaml # type: ignore[import]
+import torch
+import numpy as np
+import random
 
 def read_config(path: str|Dict) -> Dict: 
     if isinstance(path, dict): return path
     with open(path, 'r') as f: return yaml.safe_load(f)
+
+def seed(s:int):
+    # reference: https://docs.pytorch.org/docs/stable/notes/randomness.html
+    random.seed(s)
+    np.random.seed(s)
+
+    torch.manual_seed(s)
+    torch.cuda.manual_seed_all(s)
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.benchmark = False
+    torch.backends.cudnn.deterministic = True
+    torch.mps.manual_seed(s)


### PR DESCRIPTION
## Overview
This PR adds in support for manual seeding in the training step only - I didn't think any other regions of the code required this. The reason being is that either other portions of the code are already deterministic, or that if a user was trying to directly use the `simulate` portion of the code, they'd have to set the manual seed according to their run, since I no longer have control over the code they place in between runs.

It references heavily they pytorch docs for best seeding practices: https://docs.pytorch.org/docs/stable/notes/randomness.html
