### PR TITLE
Resolve the subampling n_samples > n_endmembers bug

### DIFF
--- a/src/cover_class/subsample/subsampler.py
+++ b/src/cover_class/subsample/subsampler.py
@@ -36,6 +36,7 @@ def convex_hull(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **k
 
 def kmedoids(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
     ''' NOTE: this is only for Euclidean distances '''
+    n_samples = min(len(data_matrix), n_samples)
     pca = PCA(n_components=num_pc, svd_solver="arpack", random_state=0)
     Z_c = pca.fit_transform(data_matrix)
     centroids_idx = KMedoids(n_clusters=n_samples, **kwargs).fit(Z_c).medoid_indices_
@@ -44,6 +45,7 @@ def kmedoids(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwar
 
 def kmeans(data_matrix: NDArray[np.float32], num_pc:int, n_samples:int, **kwargs) -> FloatTensor:
     ''' NOTE: this is only for Euclidean distances '''
+    n_samples = min(len(data_matrix), n_samples)
     pca = PCA(n_components=num_pc, svd_solver="arpack", random_state=0)
     Z_c = pca.fit_transform(data_matrix)
     centroids_pca = KMeans(n_clusters=n_samples, **kwargs).fit(Z_c).cluster_centers_

--- a/tests/subsample/subsampler_test.py
+++ b/tests/subsample/subsampler_test.py
@@ -45,6 +45,11 @@ class subsampleTest(unittest.TestCase):
         vertices = torch.from_numpy(manual_convex_hull_check[vertices]).to(dtype=torch.float32)
         self.assertTrue(all([i in sample for i in vertices]))
 
+        # test to confirm the subsampling works when n_samples << n_requested_samples
+        n_samples = 10
+        sample = subsampler.convex_hull(np.random.random((n_samples,n_samples)), self.num_pc, n_samples*2)
+        self.assertIsInstance(sample, FloatTensor) # just check to see if it ran w/o error
+
     def test_kmeans(self):
         '''This just tests that the function itself works'''
         self.preamble()
@@ -55,6 +60,11 @@ class subsampleTest(unittest.TestCase):
         self.assertEqual(len(sample), n_samples)
         self.assertTrue( np.all(map(lambda x: np.any(np.isclose(x, self.data_matrix)), sample)) )
 
+        # test to confirm the subsampling works when n_samples << n_requested_samples
+        sample = subsampler.kmeans(np.random.random((n_samples,n_samples)), self.num_pc, n_samples*2)
+        self.assertIsInstance(sample, FloatTensor)
+        self.assertEqual(len(sample), n_samples)
+
     def test_kmedoids(self):
         '''This just tests that the function itself works'''
         self.preamble()
@@ -64,6 +74,11 @@ class subsampleTest(unittest.TestCase):
         self.assertEqual(sample.dtype, torch.float32)
         self.assertEqual(len(sample), n_samples)
         self.assertTrue( np.all(map(lambda x: np.any(np.isclose(x, self.data_matrix)), sample)) )
+
+        # test to confirm the subsampling works when n_samples << n_requested_samples
+        sample = subsampler.kmedoids(np.random.random((n_samples,n_samples)), self.num_pc, n_samples*2)
+        self.assertIsInstance(sample, FloatTensor)
+        self.assertEqual(len(sample), n_samples)
 
     def test_lhs(self):
         '''This just tests that the function itself works'''


### PR DESCRIPTION
## Overview
This PR resolves the issue where the number of samples requested in the K-Means and K-Medoids subsampling methods is greater than the number of datapoint. It currently causes a `ValueError`. Now, it just makes the `min(n_datapoints, n_requested_samples)` as the number of samples to get.

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/35

## Testing
Added additional cases in the unit tests and did regression testing to confirm it works as intended.
Run with `make test`
```
(emit-fc) makiper@MT-400290 cover-class % make test
python3 -m unittest discover tests -p '*_test.py'
......................
----------------------------------------------------------------------
Ran 22 tests in 0.430s

OK
```