### PR TITLE
Pass in test data and label references to the simulaiton test set generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ To generate a simulated test set:
 ```
 from cover_class.train import make_simulation_test_set
 
-test_fractions = make_simulation_test_set(
+simulated_test_data, simulated_test_labels, simulated_test_fractions = make_simulation_test_set(
     dataloader,
-    test_data, 
-    test_labels,
+    real_test_data, 
+    real_test_labels,
     simulated_test_set_n_rows = <some_number>
 )
 ```

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ To get the dirichlet fractions, after every iteration, check `dataloader.dataset
 
 To generate a simulated test set:
 ```
-from cover_class.train import test_data, test_labels, test_fractions = make_simulation_test_set(
+from cover_class.train import make_simulation_test_set
+
+test_fractions = make_simulation_test_set(
     dataloader,
+    test_data, 
+    test_labels,
     simulated_test_set_n_rows = <some_number>
 )
 ```

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from cover_class.dataloader import dataloader_from_config, OrchestratorDataset
 from cover_class.utils import read_config, seed as sseed
 from cover_class.subsample import subsample_from_config, train_test_split, drop_bad_bands
-from cover_class.simulation import run_simulation, SimulationArgs
+from cover_class.simulation import run_simulation, SimulationArgs, DataArgs
 from cover_class.static.retrieval import make_hdf5
 
 def setup_training_from_config(
@@ -71,13 +71,17 @@ def setup_training_from_config(
 
 def make_simulation_test_set(
         odl: DataLoader,
+        test_spectra: FloatTensor,
+        test_labels: Tensor,
         simulated_test_set_n_rows: int = 0
+
     ) -> Tuple[FloatTensor, LongTensor, FloatTensor | None]:
     ods: OrchestratorDataset = odl.dataset # type: ignore
     test_sim_config_args: SimulationArgs = deepcopy(ods.args.sim_config_args) # type: ignore
+    test_data_config_args = DataArgs(test_spectra, test_labels)
     test_sim_config_args.n_iters = simulated_test_set_n_rows
 
     return run_simulation(
         test_sim_config_args, 
-        ods.args.sim_data_args # type: ignore
+        test_data_config_args,
     )


### PR DESCRIPTION
## Overview
This PR adds in the ability to pass in a test suite into the simulated data generator so that it can reference the test data instead of the train data.

> [!NOTE] 
> Since this is a very small PR and the need for speed, I will be merging it without a review