### PR TITLE
Band Definition Tracking

### DIFF
--- a/models/training_example.py
+++ b/models/training_example.py
@@ -101,7 +101,7 @@ def run_pipeline_classifier(
         print("Creating HDF5s from config")
         generate_hdf5_from_config(static_config)
         
-    dataloader, test_X, test_Y, _ = setup_training_from_config(config, batch_size, True, seed, outdir)
+    dataloader, test_X, test_Y = setup_training_from_config(config, batch_size, True, seed, outdir)
 
     ## create simulation eval set
     sseed(seed)

--- a/models/training_example.py
+++ b/models/training_example.py
@@ -101,7 +101,7 @@ def run_pipeline_classifier(
         print("Creating HDF5s from config")
         generate_hdf5_from_config(static_config)
         
-    dataloader, test_X, test_Y = setup_training_from_config(config, batch_size, True, seed, outdir)
+    dataloader, test_X, test_Y, _ = setup_training_from_config(config, batch_size, True, seed, outdir)
 
     ## create simulation eval set
     sseed(seed)

--- a/src/cover_class/subsample/__init__.py
+++ b/src/cover_class/subsample/__init__.py
@@ -8,6 +8,7 @@ from cover_class.subsample.forward_pipeline import (
     train_test_split,
     subsample_from_config,
     drop_bad_bands,
+    drop_bad_banddef
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "train_test_split",
     "subsample_from_config",
     "drop_bad_bands",
+    "drop_bad_banddef"
 ]

--- a/src/cover_class/subsample/forward_pipeline.py
+++ b/src/cover_class/subsample/forward_pipeline.py
@@ -51,3 +51,21 @@ def drop_bad_bands(
         mask ^= (banddef >= low) & (banddef <= high)
     spectra = np.delete(data_matrix, ~mask, axis=-1)
     return spectra
+
+def drop_bad_banddef(
+        banddef: NDArray, 
+        drop_wl_ranges: Optional[List[List[int]]] = None,
+    ) -> NDArray[np.float32]
+    """
+    References https://github.com/emit-sds/SpecTf/blob/main/spectf/utils.py#L104
+    Removes bands/wavelengths of high uncertainty from band definition.
+    """
+    if drop_wl_ranges is None or not len(drop_wl_ranges):
+        return banddef 
+
+    mask = np.ones_like(banddef, dtype=bool)
+    for low, high in drop_wl_ranges:
+        mask ^= (banddef >= low) & (banddef <= high)
+    banddef = banddef[mask]
+
+    return banddef

--- a/src/cover_class/subsample/forward_pipeline.py
+++ b/src/cover_class/subsample/forward_pipeline.py
@@ -55,7 +55,7 @@ def drop_bad_bands(
 def drop_bad_banddef(
         banddef: NDArray, 
         drop_wl_ranges: Optional[List[List[int]]] = None,
-    ) -> NDArray[np.float32]
+    ) -> NDArray[np.float32]:
     """
     References https://github.com/emit-sds/SpecTf/blob/main/spectf/utils.py#L104
     Removes bands/wavelengths of high uncertainty from band definition.

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from cover_class.dataloader import dataloader_from_config, OrchestratorDataset
 from cover_class.utils import read_config, seed as sseed
-from cover_class.subsample import subsample_from_config, train_test_split, drop_bad_bands
+from cover_class.subsample import subsample_from_config, train_test_split, drop_bad_bands, drop_bad_banddef
 from cover_class.simulation import run_simulation, SimulationArgs, DataArgs, one_hot_encode_simulated_data
 from cover_class.static.retrieval import make_hdf5
 
@@ -41,6 +41,7 @@ def setup_training_from_config(
                 file_spectra = f['spectra'][:]
                 file_wavelengths = f.attrs['wavelengths']
                 file_spectra = drop_bad_bands(file_spectra, file_wavelengths, drop_bands)
+                file_wavelengths = drop_bad_banddef(file_wavelengths, drop_bands)
                 subsampled_spectra = subsample_from_config(config, file_spectra)
                 labels = torch.full((subsampled_spectra.shape[0],), i)
 
@@ -67,7 +68,7 @@ def setup_training_from_config(
         shuffle,
     )        
 
-    return odl, FloatTensor(test_spectra), test_labels
+    return odl, FloatTensor(test_spectra), test_labels, file_wavelengths
 
 def make_simulation_test_set(
         odl: DataLoader,

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -41,7 +41,6 @@ def setup_training_from_config(
                 file_spectra = f['spectra'][:]
                 file_wavelengths = f.attrs['wavelengths']
                 file_spectra = drop_bad_bands(file_spectra, file_wavelengths, drop_bands)
-                file_wavelengths = drop_bad_banddef(file_wavelengths, drop_bands)
                 subsampled_spectra = subsample_from_config(config, file_spectra)
                 labels = torch.full((subsampled_spectra.shape[0],), i)
 
@@ -68,7 +67,30 @@ def setup_training_from_config(
         shuffle,
     )        
 
-    return odl, FloatTensor(test_spectra), test_labels, file_wavelengths
+    return odl, FloatTensor(test_spectra), test_labels
+
+def banddef_from_config(config: str|Dict) -> FloatTensor:
+    """
+    Drops the appropriate bands from the band definition
+    """
+    config = read_config(config)
+    drop_bands = config['drop-bands-wavelengths']
+    file_wavelengths = Tensor()
+
+    for i, d in enumerate(config['datasets']):
+        hdf5_list = config['datasets'][d]
+        if hdf5_list is None: continue
+        # subsampling and train test split will happen on a per file basis
+        for hdf5 in hdf5_list:
+            with h5py.File(hdf5, 'r') as f:
+                file_wavelengths = f.attrs['wavelengths']
+                file_wavelengths = drop_bad_banddef(file_wavelengths, drop_bands)
+                break
+        if file_wavelengths.numel() != 0:
+            break
+
+    return file_wavelengths
+
 
 def make_simulation_test_set(
         odl: DataLoader,

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -5,6 +5,7 @@ from torch.utils.data import DataLoader
 import torch
 import h5py # type: ignore[import]
 from copy import deepcopy
+import numpy as np
 
 from cover_class.dataloader import dataloader_from_config, OrchestratorDataset
 from cover_class.utils import read_config, seed as sseed
@@ -75,7 +76,7 @@ def banddef_from_config(config: str|Dict) -> FloatTensor:
     """
     config = read_config(config)
     drop_bands = config['drop-bands-wavelengths']
-    file_wavelengths = Tensor()
+    file_wavelengths = np.array([])
 
     for i, d in enumerate(config['datasets']):
         hdf5_list = config['datasets'][d]
@@ -86,7 +87,7 @@ def banddef_from_config(config: str|Dict) -> FloatTensor:
                 file_wavelengths = f.attrs['wavelengths']
                 file_wavelengths = drop_bad_banddef(file_wavelengths, drop_bands)
                 break
-        if file_wavelengths.numel() != 0:
+        if len(file_wavelengths) != 0:
             break
 
     return file_wavelengths

--- a/tests/subsample/forward_pipeline_test.py
+++ b/tests/subsample/forward_pipeline_test.py
@@ -57,7 +57,7 @@ class subsampleTest(unittest.TestCase):
     def test_drop_bad_bands(self):
         banddef = torch.tensor([400, 500, 600, 700, 800], dtype=torch.float32)
         data_matrix = torch.arange(10, dtype=torch.float32).reshape(2, 5)
-        drop_wl_ranges = [[450, 650], [800, 800]]  # Drop 500–600 nm bands and 800 nm band
+        drop_wl_ranges = [[450, 650], [800, 800]]  # Drop 500-600 nm bands and 800 nm band
 
         result = forward_pipeline.drop_bad_bands(data_matrix.numpy(), banddef.numpy(), drop_wl_ranges)
 
@@ -66,6 +66,18 @@ class subsampleTest(unittest.TestCase):
 
         np.testing.assert_array_equal(result, expected)
         self.assertEqual(result.shape, expected.shape)
+    
+    def test_drop_bad_banddef(self):
+        banddef = torch.tensor([400, 500, 600, 700, 800], dtype=torch.float32)
+        drop_wl_ranges = [[450, 650], [800, 800]]  # Drop 500-600 nm bands and 800 nm band
+        
+        result = forward_pipeline.drop_bad_banddef(banddef.numpy(), drop_wl_ranges)
+
+        expected = torch.tensor([400, 700], dtype=torch.float32)
+
+        np.testing.assert_array_equal(result, expected)
+        self.assertEqual(result.shape, expected.shape)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Models such as SpecTf need not only the spectra, but also the wavelengths of each band. This can be difficult to keep consistent, especially when some bands are dropped during preprocessing. This band definition is also kept inside of the HDF5 dataset files, which are not exposed in the main training loop.

This PR adds the updated band definition as a returned variable of `setup_training_from_config()`, keeping everything in one place. This is accomplished with the addition of the `drop_bad_banddef()` function, which uses the same logic and mechanism to drop the correct bands.