### PR TITLE
Downgrade Numpy and Add in Spectral Package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "requests>=2.32.5",
   "scikit-learn-extra>=0.3.0",
   "tqdm>=4.67.1",
+  "spectral>=0.24",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 dependencies = [
   "torch>=2.8.0",
   "msgspec>=0.19.0",
-  "numpy>=2.3.2",
+  "numpy<2",
   "pyyaml>=6.0.2",
   "h5py>=3.14.0",
   "pandas>=2.3.2",


### PR DESCRIPTION
## Overview
This PR is to downgrade the Numpy package version to be below 2.x as per [this issue](https://github.com/emit-sds/cover-class/issues/49). Having a Numpy version greater than or equal to 2.x breaks scikit-learn-extra. However, it should be noted that all tests do pass with Numpy version greater than 2.x, so it is likely safe to upgrade after this package's installation (it is just cumbersome).

Additionally, it adds in the `spectral` package so that `envi` can be imported. 

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/49

## Testing
Create an empty environment and check that numpy is not installed: `condo create -n tmp python=3.14 && conda activate tmp && pip3 list -v | grep -i numpy`

Then install the cover-class package with `pip3 install -e .` and confirm it works in tests.