### PR TITLE
Update metric figure labels

### DIFF
--- a/src/cover_class/reporting/metrics.py
+++ b/src/cover_class/reporting/metrics.py
@@ -36,12 +36,13 @@ def confusion_matrix(
     for c in range(n_classes):
         ax = axes[c]
         cmo = cm(y[:, c], y_hat[:, c])
+        pct = cmo / cmo.sum() * 100
         ax.imshow(cmo, cmap="Blues")
         ax.set_title(class_names[c])
         ax.set_xlabel("Predicted")
         ax.set_ylabel("True")
         for (i, j), v in np.ndenumerate(cmo):
-            ax.text(j, i, str(v), ha="center", va="center", color="black")
+            ax.text(j, i, f"{v}\n({pct[i,j]:.1f}%)", ha="center", va="center", color="black" if pct[i,j]<0.33 else "white")
 
     fig.tight_layout()
     return fig
@@ -120,8 +121,9 @@ def missed_class_confusion(
 
     for i in range(n_classes):
         for j in range(n_classes):
-            if not (v := masked_miss_confusion_mat[i,j]):
-                ax.text(j, i, f"{v:.1f}%", ha="center", va="center", color="white" if im.norm(v) > .5 else "black", fontsize=9)
+            if not masked_miss_confusion_mat[i, j]:
+                v = masked_miss_confusion_mat[i, j]
+                ax.text(j, i, f"{float(v):.1f}%", ha="center", va="center", color="white" if im.norm(v) > .5 else "black", fontsize=9)
 
     cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
     cbar.set_label("% misses")


### PR DESCRIPTION
## Overview
This PR adds adds in updates to the report metric PDF figures, adding in a few label changes. This should make it easier to read.

<img width="779" height="452" alt="Screenshot 2025-12-16 at 11 18 00 AM" src="https://github.com/user-attachments/assets/8492ec7c-55e4-4259-9b35-831896cd7b97" />

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/52
resolves https://github.com/emit-sds/cover-class/issues/53