### PR TITLE
Per-Class Thresholds for the Report metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ with Report(
                 "optimizer": "Muon",
             },
         ),
-        classification_threshold=0.1,
+        classification_threshold=[0.3 for _ in range(num_classes)],
         X_test=test_data,
         Y_test=test_labels,
         random_seed=42,

--- a/models/training_example.py
+++ b/models/training_example.py
@@ -155,7 +155,7 @@ def run_pipeline_classifier(
         ),
         X_test=simulation_x_test,
         Y_test=simulation_y_test,
-        classification_threshold = 0.1,
+        classification_threshold = [0.3 for _ in range(num_classes)],
         random_seed=seed,
     ) as report:
         

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -46,7 +46,7 @@ class Report:
     X_test: Union[Tensor, NDArray]
     Y_test: Union[Tensor, NDArray]
 
-    classification_threshold: float = 0.5
+    classification_threshold: Optional[List[float]] = None
     train_plots: List[GenLinePlot] = field(default_factory=list)
     test_plots: List[GenLinePlot] = field(default_factory=list)
     train_figures: List[Figure] = field(default_factory=list)
@@ -69,6 +69,13 @@ class Report:
 
         if self.author is None:
             self.author = getpass.getuser()
+
+        # make the per-class classification thresholds
+        n_classes = self.Y_test.shape[-1]
+        if self.classification_threshold is not None:
+            assert len(self.classification_threshold) == n_classes, f"There are {len(self.classification_threshold)} class thresholds, but {n_classes} classes"
+        else:
+            self.classification_threshold = [0.5 for _ in range(n_classes)]
 
         # finally, make sure that all of the qualitative scenes are installed
         if len(self.qualitative_testing_scenes_paths):
@@ -94,7 +101,7 @@ class Report:
         else:
             y_hat = torch.from_numpy(self.model_config.model(self.X_test))
             y_hat = torch.sigmoid(y_hat)
-        y_hat = (y_hat >= self.classification_threshold).to(torch.long)
+        y_hat = (y_hat >= torch.tensor(self.classification_threshold)).to(torch.long)
         y_hat = make_numpy(y_hat)
 
         # 1. Get Metrics


### PR DESCRIPTION
## Overview
This PR adds in the support for per-class classification thresholds for the Reporting methods. This is a logical improvement over the single-threshold for every class. Now a user can define the thresholds they way to use in their reporting if they happen to check for something like per-class best F1 scores.

The thresholds need to be passed in as a list or pytorch tensor and be the same size as the number of classes.

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/60

## Testing
The test conducted for this was to actually run the [example](https://github.com/emit-sds/cover-class/blob/develop/models/README.md) and confirm that the output is logical, which is sufficient for the recourse constraints and scope of this PR