### PR TITLE
Add Optional Run Name ID

### DIFF
--- a/models/training_example.py
+++ b/models/training_example.py
@@ -8,7 +8,7 @@ import os
 import getpass
 import matplotlib.pyplot as plt
 
-from cover_class.train import setup_training_from_config, make_simulation_test_set #type: ignore
+from cover_class.train import setup_training_from_config, make_simulation_test_set, make_run_name #type: ignore
 from cover_class.static.retrieval import generate_hdf5_from_config #type: ignore
 from cover_class.utils import seed as sseed #type: ignore
 from cover_class.reporting import ModelConfig, Report #type: ignore
@@ -100,8 +100,9 @@ def run_pipeline_classifier(
     if static_config:
         print("Creating HDF5s from config")
         generate_hdf5_from_config(static_config)
-        
-    dataloader, test_X, test_Y = setup_training_from_config(config, batch_size, True, seed, outdir)
+    
+    run_name = make_run_name()
+    dataloader, test_X, test_Y = setup_training_from_config(config, batch_size, True, seed, outdir, run_name)
 
     ## create simulation eval set
     sseed(seed)
@@ -157,6 +158,7 @@ def run_pipeline_classifier(
         Y_test=simulation_y_test,
         classification_threshold = [0.3 for _ in range(num_classes)],
         random_seed=seed,
+        run_name=run_name,
     ) as report:
         
         for batch_X, batch_Y in dataloader:

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -58,6 +58,7 @@ class Report:
     random_seed: Optional[int] = None
     notes: Optional[str] = None
     timestamp: Optional[str] = None
+    run_name: Optional[str] = None
     qualitative_testing_scenes_paths: List[str] = field(default_factory=list)
     _download_missing_qualitative_testing_scenes_from_config: bool = True
 
@@ -125,7 +126,8 @@ class Report:
 
         # 2. Generate Report
         os.makedirs(self.outdir, exist_ok=True)
-        pdf_path = os.path.join(self.outdir, f"{self.model_config.model_name}_{str(self.timestamp).replace(":", "-")}.pdf")
+        rn = self.run_name if self.run_name else str(self.timestamp).replace(":", "-")
+        pdf_path = os.path.join(self.outdir, f"{self.model_config.model_name}_{rn}.pdf")
         json_path = pdf_path.replace('.pdf', '.json')
         generate_pdf_report(self, pdf_path)
         generate_json_report(self, json_path)

--- a/src/cover_class/static/retrieval.py
+++ b/src/cover_class/static/retrieval.py
@@ -60,7 +60,7 @@ def vfs_csv(path:str|BytesIO) -> Tuple[NDArray[np.float32], NDArray[np.float32]]
     return wavelengths, spectra
 
 
-def make_hdf5(original_path:str, outpath:str, class_:str, wavelengths:torch.Tensor, spectra:torch.FloatTensor, **attrs) -> str:
+def make_hdf5(original_path:str, outpath:str, class_:str, wavelengths:torch.Tensor, spectra:torch.FloatTensor, run_name: str = '', **attrs) -> str:
     '''
     HDF5 contents:
     datasets:
@@ -73,7 +73,7 @@ def make_hdf5(original_path:str, outpath:str, class_:str, wavelengths:torch.Tens
     HDF5 output location: '{outpath}/{name of class from config file}_{original data filename}.hdf5'
     '''
     ofn = Path(original_path).stem
-    outname = Path(outpath)/f'{class_}_{ofn}.hdf5'
+    outname = Path(outpath)/f'{class_}_{ofn}{run_name}.hdf5'
     with h5py.File(outname, 'w') as f:
         f.create_dataset('spectra', data=spectra)
         f.attrs['wavelengths'] = wavelengths

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -6,6 +6,7 @@ import torch
 import h5py # type: ignore[import]
 from copy import deepcopy
 import numpy as np
+from datetime import datetime
 
 from cover_class.dataloader import dataloader_from_config, OrchestratorDataset
 from cover_class.utils import read_config, seed as sseed
@@ -13,12 +14,16 @@ from cover_class.subsample import subsample_from_config, train_test_split, drop_
 from cover_class.simulation import run_simulation, SimulationArgs, DataArgs, one_hot_encode_simulated_data
 from cover_class.static.retrieval import make_hdf5
 
+def make_run_name() -> str:
+    return datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+
 def setup_training_from_config(
         config: str|Dict, 
         batch_size: int,
         shuffle: bool = True,
         seed: Optional[int] = None,
-        subsampled_files_outdir: str = ''
+        subsampled_files_outdir: str = '',
+        run_name: str = '',
     ) -> Tuple[DataLoader, FloatTensor, Tensor]:
     """
     :param: simulated_test_set_n_rows = 0 means don't return a simulated set
@@ -42,13 +47,15 @@ def setup_training_from_config(
                 file_spectra = f['spectra'][:]
                 file_wavelengths = f.attrs['wavelengths']
                 file_spectra = drop_bad_bands(file_spectra, file_wavelengths, drop_bands)
+                file_wavelengths = torch.from_numpy(drop_bad_banddef(file_wavelengths, drop_bands))
                 subsampled_spectra = subsample_from_config(config, file_spectra)
                 labels = torch.full((subsampled_spectra.shape[0],), i)
 
                 if (subsampled_files_outdir != '') and (method := config['subsample']['selected-method']) is not None:
                     Path(subsampled_files_outdir).mkdir(parents=True, exist_ok=True)
                     sconf: dict = config['subsample'][str(method).lower()]
-                    make_hdf5(hdf5, subsampled_files_outdir, d+'_subsampled', file_wavelengths, subsampled_spectra, **sconf)
+                    rn = '_'+run_name if run_name else ''
+                    make_hdf5(hdf5, subsampled_files_outdir, d+'_subsampled', file_wavelengths, subsampled_spectra, rn, **sconf)
 
                 X_train, X_test, Y_train, Y_test = train_test_split(subsampled_spectra, labels, config['subsample']['test-fraction'])
 
@@ -66,11 +73,11 @@ def setup_training_from_config(
         LongTensor(train_labels.to(dtype=torch.long)),
         batch_size,
         shuffle,
-    )        
+    )
 
     return odl, FloatTensor(test_spectra), test_labels
 
-def banddef_from_config(config: str|Dict) -> FloatTensor:
+def banddef_from_config(config: str|Dict) -> Tensor:
     """
     Drops the appropriate bands from the band definition
     """
@@ -90,7 +97,7 @@ def banddef_from_config(config: str|Dict) -> FloatTensor:
         if len(file_wavelengths) != 0:
             break
 
-    return file_wavelengths
+    return torch.from_numpy(file_wavelengths)
 
 
 def make_simulation_test_set(


### PR DESCRIPTION
## Overview
This PR is to add in the option of adding in a "run name" to the training and report generating functions so that they can have optional unique IDs.

This is useful if kicking off multiple runs very quickly with all the output files intended for the same output directory. 

Usage:
```
from cover_class.train import make_simulation_test_set, make_run_name
from cover_class.reporting import Report

run_name = make_run_name()


simulated_test_data, simulated_test_labels, simulated_test_fractions = make_simulation_test_set(
   ...,
   run_name= run_name,
)

with Report(
        ...
        run_name= run_name,
)
```

This will generate all output files with the suffix of the run name. The "run name" is typically a timestamp string.

## Related Tickets 
resolves https://github.com/emit-sds/cover-class/issues/65

## Testing
passes regression "make test" and the training example