### PR TITLE
Updated Report Generation Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ report.test_figures.append(
     some_cool_test_figure_generator_from_my_data(model, test_data)
 )
 report.test_metric_table.update(
-    {'import test metric': generate_test_metric(model, test_data)}
+    {'important test metric': generate_test_metric(model, test_data)}
 )
 
 ## Finally, generate the report

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Takes in:
     - a list of self-made matplotlib figures to include
 - A number of other parameters to properly generate the report
 
-The Report can be generated once a context block is finished, so once your training loop exists, the report will be generated. This way, you don't need to explicitly call a generation function. 
+> [!IMPORTANT]
+> It's important to instantiate the `Report` object **before** the training loop as it'll do a number of checks, allowing for early failure before the training loop.
 
 > [!IMPORTANT]
 > This report relies on setting up a `.netrc` file in the `cover-class/src/cover_class/reporting/assets/.netrc` file path. There's no real good way to avoid it. When a `Report` object is instanited, the control logic will try to download the qualitative assessment files, so there will be an early error if this is not possible. The file download only occurs whenever there aren't the detected files in `cover-class/src/cover_class/reporting/qualitative`.
@@ -72,7 +73,7 @@ test_data, test_labels = ...
 
 from cover_class.reporting import ModelConfig, Report
 
-with Report(
+report = Report(
         outdir=".",
         config="/path/to/dataloader.yml",
         author="Shun-Ichi Amari",
@@ -85,33 +86,35 @@ with Report(
                 "optimizer": "Muon",
             },
         ),
-        classification_threshold=[0.3 for _ in range(num_classes)],
-        X_test=test_data,
         Y_test=test_labels,
         random_seed=42,
         notes="Welcome to my report!"
-    ) as report:
+    )
     
-    # now do the training
-    for X, Y in dataloader:
-        model.train()
+## Now do the training
+for X, Y in dataloader:
+    model.train()
 
-        # you can also add in logs to the report
-        report.train_metric_table.update(model.generate_some_step_metric())
+    ## You can also add in logs to the report
+    report.train_metric_table.update(model.generate_some_step_metric())
 
-    # or add in any figures
-    report.train_figures.append(
-        make_some_really_import_figure_I_want_to_show_from_my_training_logs(model, train_data)
-    )
+## Or add in any figures
+report.train_figures.append(
+    make_some_really_import_figure_I_want_to_show_from_my_training_logs(model, train_data)
+)
 
-    # and then add in any testing figures or metrics to the report as well
-    report.test_figures.append(
-        some_cool_test_figure_generator_from_my_data(model, test_data)
-    )
-    report.test_metric_table.update(
-        {'import test metric': generate_test_metric(model, test_data)}
-    )
+## And then add in any testing figures or metrics to the report as well
+report.test_figures.append(
+    some_cool_test_figure_generator_from_my_data(model, test_data)
+)
+report.test_metric_table.update(
+    {'import test metric': generate_test_metric(model, test_data)}
+)
 
-    # then exit the context block....
-# and the report will be generated here!
+## Finally, generate the report
+with torch.no_grad():
+    y_hat = torch.sigmoid(model(test_data))
+    thresholds = ...
+    y_hat = (y_hat >= thresholds).to(torch.long)
+report.make_report(y_hat, thresholds)
 ```

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ for X, Y in dataloader:
 
 ## Or add in any figures
 report.train_figures.append(
-    make_some_really_import_figure_I_want_to_show_from_my_training_logs(model, train_data)
+    make_some_really_important_figure_I_want_to_show_from_my_training_logs(model, train_data)
 )
 
 ## And then add in any testing figures or metrics to the report as well
@@ -115,6 +115,5 @@ report.test_metric_table.update(
 with torch.no_grad():
     y_hat = torch.sigmoid(model(test_data))
     thresholds = ...
-    y_hat = (y_hat >= thresholds).to(torch.long)
 report.make_report(y_hat, thresholds)
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Takes in:
 > It's important to instantiate the `Report` object **before** the training loop as it'll do a number of checks, allowing for early failure before the training loop.
 
 > [!IMPORTANT]
-> This report relies on setting up a `.netrc` file in the `cover-class/src/cover_class/reporting/assets/.netrc` file path. There's no real good way to avoid it. When a `Report` object is instanited, the control logic will try to download the qualitative assessment files, so there will be an early error if this is not possible. The file download only occurs whenever there aren't the detected files in `cover-class/src/cover_class/reporting/qualitative`.
+> This report relies on setting up a `.netrc` file in the `cover-class/src/cover_class/reporting/assets/.netrc` file path. There's no real good way to avoid it. When a `Report` object is instantiated, the control logic will try to download the qualitative assessment files, so there will be an early error if this is not possible. The file download only occurs whenever there aren't the detected files in `cover-class/src/cover_class/reporting/qualitative`.
 >
 > Steps:
 > 1. Set up an account at [https://urs.earthdata.nasa.gov](https://urs.earthdata.nasa.gov)

--- a/models/training_example.py
+++ b/models/training_example.py
@@ -140,7 +140,8 @@ def run_pipeline_classifier(
     accumulator = 0
     losses = {"Welford arithmetic mean": 0., "loss": []}
 
-    with Report(
+    ## NOTE: It's important to instantiate the report object before the training run
+    report = Report(
         outdir=outdir,
         config=config,
         author=getpass.getuser(),
@@ -154,43 +155,48 @@ def run_pipeline_classifier(
                 "dims": [test_X.shape[1], 128, 64, 32, num_classes]
             },
         ),
-        X_test=simulation_x_test,
         Y_test=simulation_y_test,
-        classification_threshold = [0.3 for _ in range(num_classes)],
         random_seed=seed,
         run_name=run_name,
-    ) as report:
-        
-        for batch_X, batch_Y in dataloader:
-            accumulator += 1
-            if accumulator == max_training_steps:
-                break
+    )
+    
+    for batch_X, batch_Y in dataloader:
+        accumulator += 1
+        if accumulator == max_training_steps:
+            break
 
-            optimizer.zero_grad(set_to_none=True)
-            logits: torch.Tensor = model(batch_X)
-            loss: torch.Tensor = criterion(logits, batch_Y)
-            loss.backward()
-            optimizer.step()
-        
-            nats = loss.item()
+        optimizer.zero_grad(set_to_none=True)
+        logits: torch.Tensor = model(batch_X)
+        loss: torch.Tensor = criterion(logits, batch_Y)
+        loss.backward()
+        optimizer.step()
+    
+        nats = loss.item()
 
-            losses["loss"].append(nats) #type: ignore
-            losses["Welford arithmetic mean"] = losses["Welford arithmetic mean"] + (nats - losses["Welford arithmetic mean"])/accumulator # type: ignore
-            
-            if log_interval is not None and (accumulator % log_interval == 0 or accumulator == 0):
-                print(f"Step {accumulator:>7} | BCE loss: {nats:.4f} nats | Running average mean: {losses["Welford arithmetic mean"]:.4f}")
+        losses["loss"].append(nats) #type: ignore
+        losses["Welford arithmetic mean"] = losses["Welford arithmetic mean"] + (nats - losses["Welford arithmetic mean"])/accumulator # type: ignore
         
-        ## Save model
-        torch.save(model.state_dict(), os.path.join(outdir, 'model.pth'))
-        model.eval()
+        if log_interval is not None and (accumulator % log_interval == 0 or accumulator == 0):
+            print(f"Step {accumulator:>7} | BCE loss: {nats:.4f} nats | Running average mean: {losses["Welford arithmetic mean"]:.4f}")
+    
+    ## Save model
+    torch.save(model.state_dict(), os.path.join(outdir, 'model.pth'))
+    model.eval()
 
-        ## generate a training loss plot in the report as well
-        fig, ax = plt.subplots()
-        ax.plot(losses["loss"]) # type: ignore
-        ax.set_title("Training Loss")
-        ax.set_xlabel("Step")
-        ax.set_ylabel("BCE nats")
-        report.train_figures.append(fig)
+    ## Generate a training loss plot in the report as well
+    fig, ax = plt.subplots()
+    ax.plot(losses["loss"]) # type: ignore
+    ax.set_title("Training Loss")
+    ax.set_xlabel("Step")
+    ax.set_ylabel("BCE nats")
+    report.train_figures.append(fig)
+
+    ## Finally, generate the report
+    with torch.no_grad():
+        y_hat = torch.sigmoid(model(simulation_x_test))
+        thresholds = torch.tensor([0.5] * y_hat.shape[-1], device=y_hat.device, dtype=y_hat.dtype)
+        y_hat = (y_hat >= thresholds).to(torch.long)
+    report.make_report(y_hat, thresholds.tolist())
 
 if __name__ == "__main__": 
     run_pipeline_classifier()

--- a/models/training_example.py
+++ b/models/training_example.py
@@ -194,9 +194,8 @@ def run_pipeline_classifier(
     ## Finally, generate the report
     with torch.no_grad():
         y_hat = torch.sigmoid(model(simulation_x_test))
-        thresholds = torch.tensor([0.5] * y_hat.shape[-1], device=y_hat.device, dtype=y_hat.dtype)
-        y_hat = (y_hat >= thresholds).to(torch.long)
-    report.make_report(y_hat, thresholds.tolist())
+    thresholds = [0.5] * y_hat.shape[-1]
+    report.make_report(y_hat, thresholds)
 
 if __name__ == "__main__": 
     run_pipeline_classifier()

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -51,7 +51,6 @@ class Report:
     test_figures: List[Figure] = field(default_factory=list)
     train_metric_table: Optional[dict] = None
     test_metric_table: Optional[dict] = None
-    class_thresholds: List[float] = field(default_factory=list)
     author: Optional[str] = None
     wandb_link: Optional[str] = None
     random_seed: Optional[int] = None
@@ -80,20 +79,27 @@ class Report:
             uris = read_config(self.config).get("test-scene-urls", [])
             self.qualitative_testing_scenes_paths.extend(download_scenes(uris))
 
-    def make_report(self, y_hat: Union[Tensor, NDArray], class_thresholds: Optional[List[float]] = None):
-        y_hat = make_numpy(y_hat)
+    def make_report(self, y_hat: Tensor, class_thresholds: List[float]):
+        assert len(class_thresholds) == y_hat.shape[-1], f"Got {len(class_thresholds)} thresholds for {y_hat.shape[-1]} classes"
+
+        y_hat_binary = (y_hat >= torch.tensor(class_thresholds, device=y_hat.device, dtype=y_hat.dtype)).to(torch.long)
+        y_hat_binary = make_numpy(y_hat_binary) # type: ignore
+        y_hat = make_numpy(y_hat) # type: ignore
 
         # 1. Get Metrics
         ds: Dict = self.config['datasets'] # type: ignore
         class_names = [str(c) for c in ds.keys() if ds[c] is not None and len(ds[c])]
+        
         assert y_hat.shape[-1] == len(class_names), f"Got {y_hat.shape[-1]} classes in y_hat, but {len(class_names)} classes from the config"
-        cm_plot            = confusion_matrix(y_hat, self.Y_test, class_names)
-        mcc_plot           = missed_class_confusion(y_hat, self.Y_test, class_names)
-        rates              = tpr_fpr(y_hat, self.Y_test, class_names)
-        f1_scores          = f_beta_scores(y_hat, self.Y_test, class_names)
+        assert len(class_thresholds) == len(class_names), f"Got {len(class_thresholds)} class thresholds, but {len(class_names)} classes from the config"
+
+        cm_plot            = confusion_matrix(y_hat_binary, self.Y_test, class_names)
+        mcc_plot           = missed_class_confusion(y_hat_binary, self.Y_test, class_names)
+        rates              = tpr_fpr(y_hat_binary, self.Y_test, class_names)
+        f1_scores          = f_beta_scores(y_hat_binary, self.Y_test, class_names)
         roc_plot, roc_dict = roc_auc(y_hat, self.Y_test, class_names)
         # zip together the metric dicts
-        metrics: Dict = {c:{} for c in class_names}
+        metrics: Dict = {class_names[i]:{'Threshold': class_thresholds[i]} for i in range(len(class_names))}
         for m in [rates, f1_scores, roc_dict]:
             for k, v in m.items():
                 metrics[k].update(v)
@@ -102,12 +108,6 @@ class Report:
         if self.test_metric_table is None:
             self.test_metric_table = {}
         self.test_metric_table.update(metrics)
-
-        self.class_thresholds = class_thresholds or self.class_thresholds
-        if self.class_thresholds:
-            assert len(self.class_thresholds) == len(class_names), f"Got {len(self.class_thresholds)} classes thresholds, but {len(class_names)} classes from the config"
-            for i in range(len(class_names)):
-                self.test_metric_table[class_names[i]]['Threshold'] = self.class_thresholds[i]
 
         # 2. Generate Report
         os.makedirs(self.outdir, exist_ok=True)

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -43,16 +43,15 @@ class Report:
     outdir: str
     config: str|Dict
     model_config: ModelConfig
-    X_test: Union[Tensor, NDArray]
     Y_test: Union[Tensor, NDArray]
 
-    classification_threshold: Optional[List[float]] = None
     train_plots: List[GenLinePlot] = field(default_factory=list)
     test_plots: List[GenLinePlot] = field(default_factory=list)
     train_figures: List[Figure] = field(default_factory=list)
     test_figures: List[Figure] = field(default_factory=list)
     train_metric_table: Optional[dict] = None
     test_metric_table: Optional[dict] = None
+    class_thresholds: List[float] = field(default_factory=list)
     author: Optional[str] = None
     wandb_link: Optional[str] = None
     random_seed: Optional[int] = None
@@ -71,13 +70,6 @@ class Report:
         if self.author is None:
             self.author = getpass.getuser()
 
-        # make the per-class classification thresholds
-        n_classes = self.Y_test.shape[-1]
-        if self.classification_threshold is not None:
-            assert len(self.classification_threshold) == n_classes, f"There are {len(self.classification_threshold)} class thresholds, but {n_classes} classes"
-        else:
-            self.classification_threshold = [0.5 for _ in range(n_classes)]
-
         # finally, make sure that all of the qualitative scenes are installed
         if len(self.qualitative_testing_scenes_paths):
             for i, f in enumerate(self.qualitative_testing_scenes_paths):
@@ -88,33 +80,20 @@ class Report:
             uris = read_config(self.config).get("test-scene-urls", [])
             self.qualitative_testing_scenes_paths.extend(download_scenes(uris))
 
-    def __enter__(self):
-        return self
-    
-    def __exit__(self, _, __, ___):
-        self.make_report()
-
-    def make_report(self):
-        if isinstance(self.model_config.model, torch.nn.Module):
-            self.model_config.model.eval()
-            with torch.no_grad():
-                y_hat = torch.sigmoid(self.model_config.model(self.X_test))
-        else:
-            y_hat = torch.from_numpy(self.model_config.model(self.X_test))
-            y_hat = torch.sigmoid(y_hat)
-        y_hat = (y_hat >= torch.tensor(self.classification_threshold)).to(torch.long)
+    def make_report(self, y_hat: Union[Tensor, NDArray], class_thresholds: Optional[List[float]] = None):
         y_hat = make_numpy(y_hat)
 
         # 1. Get Metrics
         ds: Dict = self.config['datasets'] # type: ignore
         class_names = [str(c) for c in ds.keys() if ds[c] is not None and len(ds[c])]
+        assert y_hat.shape[-1] == len(class_names), f"Got {y_hat.shape[-1]} classes in y_hat, but {len(class_names)} classes from the config"
         cm_plot            = confusion_matrix(y_hat, self.Y_test, class_names)
         mcc_plot           = missed_class_confusion(y_hat, self.Y_test, class_names)
         rates              = tpr_fpr(y_hat, self.Y_test, class_names)
         f1_scores          = f_beta_scores(y_hat, self.Y_test, class_names)
         roc_plot, roc_dict = roc_auc(y_hat, self.Y_test, class_names)
         # zip together the metric dicts
-        metrics = {c:{} for c in class_names}
+        metrics: Dict = {c:{} for c in class_names}
         for m in [rates, f1_scores, roc_dict]:
             for k, v in m.items():
                 metrics[k].update(v)
@@ -123,6 +102,12 @@ class Report:
         if self.test_metric_table is None:
             self.test_metric_table = {}
         self.test_metric_table.update(metrics)
+
+        self.class_thresholds = class_thresholds or self.class_thresholds
+        if self.class_thresholds:
+            assert len(self.class_thresholds) == len(class_names), f"Got {len(self.class_thresholds)} classes thresholds, but {len(class_names)} classes from the config"
+            for i in range(len(class_names)):
+                self.test_metric_table[class_names[i]]['Threshold'] = self.class_thresholds[i]
 
         # 2. Generate Report
         os.makedirs(self.outdir, exist_ok=True)


### PR DESCRIPTION
## Overview
This PR now changes the report generation method to now be an invokable function instead of an automatically occurring function at the end of a context window. The reason being is that users want to be able to control the way testing inference is done at a more granular level.

Please see the updated `README.md` and `models/training_example.py` for a user's guide.

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/64

## Testing
Ran regression testing with `make test`

Then did a smoke test with the example script: `python3 models/training_example.py --outdir . --config config/dataloaderyml --lr 0.0001 --batch-size 1024 --max-training-steps 100 --log-interval 20 --simulated-test-set-size 1000 --seed 42` which generated the expected output.

Thresholds are now reported as part of the class items:
<img width="824" height="254" alt="Screenshot 2026-01-05 at 5 16 18 PM" src="https://github.com/user-attachments/assets/9ccee494-6661-4613-b3f6-56f4065ba2fa" />
