### PR TITLE
File-Wise Subsampling

### DIFF
--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -26,6 +26,11 @@ simulation:
 subsample:
   test-fraction: 0.2
   selected-method: convex-hull
+  file-specific:
+    /some/path.hdf5:
+      kmedoids:
+        num_pc: 5
+        n_samples: 200
   convex-hull:
     num_pc: 1
     n_samples: 10

--- a/src/cover_class/subsample/forward_pipeline.py
+++ b/src/cover_class/subsample/forward_pipeline.py
@@ -14,23 +14,30 @@ def train_test_split(data_matrix: FloatTensor, labels:Tensor, frac_test: float, 
 
 def subsample_from_config(
         config:str|Dict, 
+        file_name: str,
         data_matrix: NDArray[np.float32], 
-    ) -> FloatTensor:
+    ) -> Tuple[FloatTensor, str]:
 
     subsample_config:Dict = read_config(config)['subsample']
-    method:str = str(subsample_config['selected-method']).lower()
+    specific = subsample_config.get('file-specific', None)
+    if specific is not None and file_name in specific:
+        method:str  = str(list(specific[file_name].keys())[0]).lower()
+        params:dict = specific[file_name][method]
+    else:
+        method = str(subsample_config['selected-method']).lower()
+        params = subsample_config.get(method, None)
     
     match method:
         case 'convex-hull':
-            return convex_hull(data_matrix, **subsample_config[method])
+            return convex_hull(data_matrix, **params), method
         case 'kmeans':
-            return kmeans(data_matrix, **subsample_config[method])
+            return kmeans(data_matrix, **params), method
         case 'kmedoids':
-            return kmedoids(data_matrix, **subsample_config[method])
+            return kmedoids(data_matrix, **params), method
         case 'lhs':
-            return lhs(data_matrix, **subsample_config[method])
+            return lhs(data_matrix, **params), method
         case _:
-            return FloatTensor(torch.from_numpy(data_matrix).to(torch.float32))
+            return FloatTensor(torch.from_numpy(data_matrix).to(torch.float32)), 'none'
     return FloatTensor() # here for mypy
 
 def drop_bad_bands(

--- a/src/cover_class/subsample/forward_pipeline.py
+++ b/src/cover_class/subsample/forward_pipeline.py
@@ -16,7 +16,7 @@ def subsample_from_config(
         config:str|Dict, 
         file_name: str,
         data_matrix: NDArray[np.float32], 
-    ) -> Tuple[FloatTensor, str]:
+    ) -> Tuple[FloatTensor, Optional[str], Optional[dict]]:
 
     subsample_config:Dict = read_config(config)['subsample']
     specific = subsample_config.get('file-specific', None)
@@ -29,15 +29,15 @@ def subsample_from_config(
     
     match method:
         case 'convex-hull':
-            return convex_hull(data_matrix, **params), method
+            return convex_hull(data_matrix, **params), method, params
         case 'kmeans':
-            return kmeans(data_matrix, **params), method
+            return kmeans(data_matrix, **params), method, params
         case 'kmedoids':
-            return kmedoids(data_matrix, **params), method
+            return kmedoids(data_matrix, **params), method, params
         case 'lhs':
-            return lhs(data_matrix, **params), method
+            return lhs(data_matrix, **params), method, params
         case _:
-            return FloatTensor(torch.from_numpy(data_matrix).to(torch.float32)), 'none'
+            return FloatTensor(torch.from_numpy(data_matrix).to(torch.float32)), None, params
     return FloatTensor() # here for mypy
 
 def drop_bad_bands(

--- a/src/cover_class/subsample/forward_pipeline.py
+++ b/src/cover_class/subsample/forward_pipeline.py
@@ -21,11 +21,13 @@ def subsample_from_config(
     subsample_config:Dict = read_config(config)['subsample']
     specific = subsample_config.get('file-specific', None)
     if specific is not None and file_name in specific:
-        method:str  = str(list(specific[file_name].keys())[0]).lower()
+        method:str  = str(list(specific[file_name].keys())[0])
         params:dict = specific[file_name][method]
+        method = method.lower()
     else:
-        method = str(subsample_config['selected-method']).lower()
+        method = str(subsample_config['selected-method'])
         params = subsample_config.get(method, None)
+        method = method.lower()
     
     match method:
         case 'convex-hull':
@@ -37,7 +39,7 @@ def subsample_from_config(
         case 'lhs':
             return lhs(data_matrix, **params), method, params
         case _:
-            return FloatTensor(torch.from_numpy(data_matrix).to(torch.float32)), None, params
+            return FloatTensor(torch.from_numpy(data_matrix).to(torch.float32)), None, None
     return FloatTensor() # here for mypy
 
 def drop_bad_bands(

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -48,14 +48,14 @@ def setup_training_from_config(
                 file_wavelengths = f.attrs['wavelengths']
                 file_spectra = drop_bad_bands(file_spectra, file_wavelengths, drop_bands)
                 file_wavelengths = torch.from_numpy(drop_bad_banddef(file_wavelengths, drop_bands))
-                subsampled_spectra = subsample_from_config(config, file_spectra)
+                subsampled_spectra, method = subsample_from_config(config, hdf5, file_spectra)
                 labels = torch.full((subsampled_spectra.shape[0],), i)
 
                 if (subsampled_files_outdir != '') and (method := config['subsample']['selected-method']) is not None:
                     Path(subsampled_files_outdir).mkdir(parents=True, exist_ok=True)
                     sconf: dict = config['subsample'][str(method).lower()]
                     rn = '_'+run_name if run_name else ''
-                    make_hdf5(hdf5, subsampled_files_outdir, d+'_subsampled', file_wavelengths, subsampled_spectra, rn, **sconf)
+                    make_hdf5(hdf5, subsampled_files_outdir, f'{d}_{method}_subsampled', file_wavelengths, subsampled_spectra, rn, **sconf)
 
                 X_train, X_test, Y_train, Y_test = train_test_split(subsampled_spectra, labels, config['subsample']['test-fraction'])
 

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -48,14 +48,13 @@ def setup_training_from_config(
                 file_wavelengths = f.attrs['wavelengths']
                 file_spectra = drop_bad_bands(file_spectra, file_wavelengths, drop_bands)
                 file_wavelengths = torch.from_numpy(drop_bad_banddef(file_wavelengths, drop_bands))
-                subsampled_spectra, method = subsample_from_config(config, hdf5, file_spectra)
+                subsampled_spectra, method, subsample_conf = subsample_from_config(config, hdf5, file_spectra)
                 labels = torch.full((subsampled_spectra.shape[0],), i)
 
-                if (subsampled_files_outdir != '') and (method := config['subsample']['selected-method']) is not None:
+                if (subsampled_files_outdir != '') and method is not None and subsample_conf is not None:
                     Path(subsampled_files_outdir).mkdir(parents=True, exist_ok=True)
-                    sconf: dict = config['subsample'][str(method).lower()]
                     rn = '_'+run_name if run_name else ''
-                    make_hdf5(hdf5, subsampled_files_outdir, f'{d}_{method}_subsampled', file_wavelengths, subsampled_spectra, rn, **sconf)
+                    make_hdf5(hdf5, subsampled_files_outdir, f'{d}_{method}_subsampled', file_wavelengths, subsampled_spectra, rn, **subsample_conf)
 
                 X_train, X_test, Y_train, Y_test = train_test_split(subsampled_spectra, labels, config['subsample']['test-fraction'])
 

--- a/tests/subsample/forward_pipeline_test.py
+++ b/tests/subsample/forward_pipeline_test.py
@@ -41,15 +41,19 @@ class subsampleTest(unittest.TestCase):
         torch.testing.assert_close(torch.from_numpy(data).to(torch.float32), result)
         self.assertEqual(method.lower(), 'none')
 
+    @patch('cover_class.subsample.forward_pipeline.lhs')
     @patch('cover_class.subsample.forward_pipeline.kmedoids')
     @patch('cover_class.subsample.forward_pipeline.read_config')
-    def test_subsample_from_config_override(self, rc_mock:Mock, kmed_mock:Mock):
+    def test_subsample_from_config_override(self, rc_mock:Mock, kmed_mock:Mock, lhs_mock:Mock):
         config = {
             'subsample': {
                 'selected-method':'convex-hull',
                 'file-specific': {
                     '/some/path.hdf5': {
                         'kmedoids': {'num_pc': 5, 'n_samples': 200}
+                    },
+                    '/some/other/path.hdf5': {
+                        'lhs': {'num_pc': 8, 'n_samples': 10, 'hypercubes_per_dimension': 2, 'samples_per_hypercube':2}
                     }
                 },
                 'convex-hull': {'num_pc':1, 'n_samples':2, 'qhull_options': 'x'},
@@ -68,6 +72,12 @@ class subsampleTest(unittest.TestCase):
         call_args = kmed_mock.call_args_list.pop()
         self.assertDictEqual(config['subsample']['file-specific']['/some/path.hdf5']['kmedoids'], call_args.kwargs) # type: ignore 
         self.assertEqual(method.lower(), 'kmedoids')
+
+        _, method = subsample_from_config('/path', '/some/other/path.hdf5', data)
+        lhs_mock.assert_called_once()
+        call_args = lhs_mock.call_args_list.pop()
+        self.assertDictEqual(config['subsample']['file-specific']['/some/other/path.hdf5']['lhs'], call_args.kwargs) # type: ignore 
+        self.assertEqual(method.lower(), 'lhs')
 
     def test_train_test_split(self):
         frac = 0.2

--- a/tests/subsample/forward_pipeline_test.py
+++ b/tests/subsample/forward_pipeline_test.py
@@ -37,9 +37,9 @@ class subsampleTest(unittest.TestCase):
 
         # test that any other value returns all data
         config['subsample']['selected-method'] = ''
-        result, method = subsample_from_config('/path', '', data)
+        result, method, _ = subsample_from_config('/path', '', data)
         torch.testing.assert_close(torch.from_numpy(data).to(torch.float32), result)
-        self.assertEqual(method.lower(), 'none')
+        self.assertEqual(method, None)
 
     @patch('cover_class.subsample.forward_pipeline.lhs')
     @patch('cover_class.subsample.forward_pipeline.kmedoids')
@@ -67,13 +67,13 @@ class subsampleTest(unittest.TestCase):
 
         # test override config - no override
         rc_mock.side_effect = lambda x: config
-        _, method = subsample_from_config('/path', '/some/path.hdf5', data)
+        _, method, _ = subsample_from_config('/path', '/some/path.hdf5', data)
         kmed_mock.assert_called_once()
         call_args = kmed_mock.call_args_list.pop()
         self.assertDictEqual(config['subsample']['file-specific']['/some/path.hdf5']['kmedoids'], call_args.kwargs) # type: ignore 
         self.assertEqual(method.lower(), 'kmedoids')
 
-        _, method = subsample_from_config('/path', '/some/other/path.hdf5', data)
+        _, method, _ = subsample_from_config('/path', '/some/other/path.hdf5', data)
         lhs_mock.assert_called_once()
         call_args = lhs_mock.call_args_list.pop()
         self.assertDictEqual(config['subsample']['file-specific']['/some/other/path.hdf5']['lhs'], call_args.kwargs) # type: ignore 

--- a/tests/subsample/forward_pipeline_test.py
+++ b/tests/subsample/forward_pipeline_test.py
@@ -29,16 +29,45 @@ class subsampleTest(unittest.TestCase):
             t, m = item
             config['subsample']['selected-method'] = t
             rc_mock.side_effect = lambda x: config
-            subsample_from_config('/path', data)
+            subsample_from_config('/path', '/example/test.txt', data)
             m.assert_called_once()
-            call_args = m.call_args_list.pop()
+            call_args = m.call_args_list.pop() 
             self.assertDictEqual(config['subsample'][t], call_args.kwargs) # type: ignore 
         list(map(check_args, {'convex-hull':cv_mock, 'kmeans':km_mock, 'kmedoids':kmed_mock, 'lhs':lhs_mock}.items()))
 
         # test that any other value returns all data
         config['subsample']['selected-method'] = ''
-        result = subsample_from_config('/path', data)
+        result, method = subsample_from_config('/path', '', data)
         torch.testing.assert_close(torch.from_numpy(data).to(torch.float32), result)
+        self.assertEqual(method.lower(), 'none')
+
+    @patch('cover_class.subsample.forward_pipeline.kmedoids')
+    @patch('cover_class.subsample.forward_pipeline.read_config')
+    def test_subsample_from_config_override(self, rc_mock:Mock, kmed_mock:Mock):
+        config = {
+            'subsample': {
+                'selected-method':'convex-hull',
+                'file-specific': {
+                    '/some/path.hdf5': {
+                        'kmedoids': {'num_pc': 5, 'n_samples': 200}
+                    }
+                },
+                'convex-hull': {'num_pc':1, 'n_samples':2, 'qhull_options': 'x'},
+                'kmeans': {'num_pc':1, 'n_samples':2, 'init': 'x'},
+                'kmedoids': {'num_pc':1, 'n_samples':2, 'metric': 'euclidean'},
+                'lhs': {'num_pc':1, 'n_samples':2, 'hypercubes_per_dimension': 3, 'samples_per_hypercube':4},
+                'fail': {},
+            },
+        }
+        data = np.array([0xD, 0xE, 0xA, 0xD, 0xD, 0xE, 0xA, 0xD])
+
+        # test override config - no override
+        rc_mock.side_effect = lambda x: config
+        _, method = subsample_from_config('/path', '/some/path.hdf5', data)
+        kmed_mock.assert_called_once()
+        call_args = kmed_mock.call_args_list.pop()
+        self.assertDictEqual(config['subsample']['file-specific']['/some/path.hdf5']['kmedoids'], call_args.kwargs) # type: ignore 
+        self.assertEqual(method.lower(), 'kmedoids')
 
     def test_train_test_split(self):
         frac = 0.2


### PR DESCRIPTION
## Overview
This PR adds in the functionality to make a file-wise subsampling method. Under `subsample/file-specific`, the user can specify a config for the subsampling method. If there is no file-specific subsampling method, then the default selected subsampling method will be used.

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/69

## Testing
Added in a new unit test, and verified all tests pass with `make test`