### PR TITLE
Pytorch DataLoader config passthrough

### DIFF
--- a/src/cover_class/dataloader/dataloader.py
+++ b/src/cover_class/dataloader/dataloader.py
@@ -134,6 +134,7 @@ def dataloader_from_config(
         labels:LongTensor,
         batch_size:int,
         shuffle: bool = True, 
+        misc_dataloader_params: dict = {},
     ) -> DataLoader:
 
     config = read_config(config)
@@ -148,4 +149,4 @@ def dataloader_from_config(
         labels.long()
     )
     ods = OrchestratorDataset(ods_args, shuffle)
-    return DataLoader(ods, batch_size=None)
+    return DataLoader(ods, batch_size=None, **misc_dataloader_params)

--- a/src/cover_class/train.py
+++ b/src/cover_class/train.py
@@ -24,6 +24,7 @@ def setup_training_from_config(
         seed: Optional[int] = None,
         subsampled_files_outdir: str = '',
         run_name: str = '',
+        misc_dataloader_params: dict = {},
     ) -> Tuple[DataLoader, FloatTensor, Tensor]:
     """
     :param: simulated_test_set_n_rows = 0 means don't return a simulated set
@@ -72,6 +73,7 @@ def setup_training_from_config(
         LongTensor(train_labels.to(dtype=torch.long)),
         batch_size,
         shuffle,
+        misc_dataloader_params,
     )
 
     return odl, FloatTensor(test_spectra), test_labels


### PR DESCRIPTION
## Overview
This PR adds in a pass through parameter for the PyTorch DataLoader config.

## Related Tickets
resolves https://github.com/emit-sds/cover-class/issues/67

## Testing
- [ ] Verified regression tests pass
- [ ] Verified smoke tests pass

```
(emit-fc) makiper@MT-400290 cover-class % make test
python3 -m unittest discover tests -p '*_test.py'
........................
----------------------------------------------------------------------
Ran 24 tests in 0.569s

OK
(emit-fc) makiper@MT-400290 cover-class %
(emit-fc) makiper@MT-400290 cover-class %
(emit-fc) makiper@MT-400290 cover-class % python3 models/training_example.py --outdir . --config config/dataloader\ copy.yml --lr 0.0001 --batch-size 1024 --max-training-steps 100 --log-interval 20 --simulated-test-set-size 1000 --seed 42
/Users/makiper/mambaforge/envs/emit-fc/lib/python3.13/site-packages/scipy/sparse/linalg/_interface.py:824: RuntimeWarning: invalid value encountered in dot
  return self.A.dot(X)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 6177.18it/s]
Step      20 | BCE loss: 0.6535 nats | Running average mean: 0.6474
Step      40 | BCE loss: 0.6188 nats | Running average mean: 0.6261
Step      60 | BCE loss: 0.5232 nats | Running average mean: 0.6097
Step      80 | BCE loss: 0.5816 nats | Running average mean: 0.5953
Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers). Got range [-0.031505488..1.2835808].
Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers). Got range [-9999.0..1.729243].
```