### PR TITLE
Add in Fractional Simulation Metric Reporting

### DIFF
--- a/models/training_example.py
+++ b/models/training_example.py
@@ -12,6 +12,7 @@ from cover_class.train import setup_training_from_config, make_simulation_test_s
 from cover_class.static.retrieval import generate_hdf5_from_config #type: ignore
 from cover_class.utils import seed as sseed #type: ignore
 from cover_class.reporting import ModelConfig, Report #type: ignore
+from cover_class.simulation.force_fractions import ForcedFractionSimulation #type: ignore
 
 ENV_VAR_PREFIX = 'COVER_CLASS_TRAIN_'
 
@@ -190,6 +191,15 @@ def run_pipeline_classifier(
     ax.set_xlabel("Step")
     ax.set_ylabel("BCE nats")
     report.train_figures.append(fig)
+
+    ## Generate fractional simulation data for each class to test model performance on
+    fraction_ranges = [(0.1, 0.5), (0.5, 0.10), (0.10, 0.15), (0.15, 0.25), (0.25, 0.5)]
+    simulated_test_set_size = 100
+    fs = ForcedFractionSimulation(dataloader, test_X, test_Y, simulated_test_set_size, fraction_ranges)
+    for frac_sim_data, _ in fs:
+        with torch.no_grad():
+            frac_sim_y_hat = torch.sigmoid(model(frac_sim_data))
+        report.append_fractional_simulation_result(fs, frac_sim_y_hat)
 
     ## Finally, generate the report
     with torch.no_grad():

--- a/models/training_example.py
+++ b/models/training_example.py
@@ -193,7 +193,7 @@ def run_pipeline_classifier(
     report.train_figures.append(fig)
 
     ## Generate fractional simulation data for each class to test model performance on
-    fraction_ranges = [(0.1, 0.5), (0.5, 0.10), (0.10, 0.15), (0.15, 0.25), (0.25, 0.5)]
+    fraction_ranges = [(0.01, 0.05), (0.05, 0.10), (0.10, 0.15), (0.15, 0.25), (0.25, 0.50)]
     simulated_test_set_size = 100
     fs = ForcedFractionSimulation(dataloader, test_X, test_Y, simulated_test_set_size, fraction_ranges)
     for frac_sim_data, _ in fs:

--- a/src/cover_class/reporting/json_report.py
+++ b/src/cover_class/reporting/json_report.py
@@ -15,7 +15,7 @@ def generate_json_report(
     out.update({'Seed':report_config.random_seed})
     out.update({'Notes':report_config.notes})
     out.update({'Train':report_config.train_metric_table})
-    out.update({'Test':report_config.test_metric_table})
+    out.update({'Test':{'metrics':report_config.test_metric_table, 'fractional simulation':report_config._fractional_simulation_test_dict}})
     out.update({'Model':
         {
             'Name':report_config.model_config.model_name,

--- a/src/cover_class/reporting/pdf_report.py
+++ b/src/cover_class/reporting/pdf_report.py
@@ -55,7 +55,8 @@ def _metrics_table(contents: List, styles: Dict, metrics: Dict, title: str) -> N
             metric_tables.append(make_table([[str(k), "Value"]] + [[str(i), str(j)] for i, j in v.items()]))
         else:
             data.append([str(k), str(v)])
-    metric_tables.append(make_table(data))
+    if len(data) >1:
+        metric_tables.append(make_table(data))
 
     # chunk into rows of 4
     rows = [metric_tables[i:i+4] for i in range(0, len(metric_tables), 4)]
@@ -243,6 +244,11 @@ def generate_pdf_report(
     contents.append(Spacer(1, 0.1 * inch))
     if report_config.test_metric_table:
         _metrics_table(contents, report_styles, report_config.test_metric_table, "Test Metrics")
+        contents.append(Spacer(1, 0.1 * inch))
+    if report_config.fractional_simulation_test_results:
+        _metrics_table(contents, report_styles, report_config._fractional_simulation_test_dict['TPR'], "Fractional Simulation TPR")
+        contents.append(Spacer(1, 0.1 * inch))
+        _metrics_table(contents, report_styles, report_config._fractional_simulation_test_dict['FPR'], "Fractional Simulation FPR")
         contents.append(Spacer(1, 0.1 * inch))
     contents.append(Paragraph("Testing Plots", report_styles["Heading2"]))
     contents.append(Spacer(1, 0.1 * inch))

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -20,6 +20,7 @@ from cover_class.reporting.json_report import generate_json_report
 from cover_class.reporting.pdf_report import generate_pdf_report
 from cover_class.reporting.download_scenes import download_scenes
 from cover_class.reporting.utils import make_numpy
+from cover_class.simulation.force_fractions import ForcedFractionSimulation
 
 @dataclass
 class GenLinePlot:
@@ -39,6 +40,14 @@ class ModelConfig:
     tags: Optional[List[str]] = None
 
 @dataclass
+class FractionalSimulationResult:
+    range_low: int
+    range_high: int
+    class_id: int
+    y_hat: Tensor
+    y: Tensor
+
+@dataclass
 class Report:
     outdir: str
     config: str|Dict
@@ -51,6 +60,7 @@ class Report:
     test_figures: List[Figure] = field(default_factory=list)
     train_metric_table: Optional[dict] = None
     test_metric_table: Optional[dict] = None
+    fractional_simulation_test_results: List[FractionalSimulationResult] = field(default_factory=list)
     author: Optional[str] = None
     wandb_link: Optional[str] = None
     random_seed: Optional[int] = None
@@ -59,6 +69,7 @@ class Report:
     run_name: Optional[str] = None
     qualitative_testing_scenes_paths: List[str] = field(default_factory=list)
     _download_missing_qualitative_testing_scenes_from_config: bool = True
+    _fractional_simulation_test_dict: Dict = field(default_factory=dict)
 
     def __post_init__(self):
         if self.timestamp is None:
@@ -89,9 +100,10 @@ class Report:
         # 1. Get Metrics
         ds: Dict = self.config['datasets'] # type: ignore
         class_names = [str(c) for c in ds.keys() if ds[c] is not None and len(ds[c])]
+        lcn = len(class_names)
         
-        assert y_hat.shape[-1] == len(class_names), f"Got {y_hat.shape[-1]} classes in y_hat, but {len(class_names)} classes from the config"
-        assert len(class_thresholds) == len(class_names), f"Got {len(class_thresholds)} class thresholds, but {len(class_names)} classes from the config"
+        assert y_hat.shape[-1] == lcn, f"Got {y_hat.shape[-1]} classes in y_hat, but {lcn} classes from the config"
+        assert len(class_thresholds) == lcn, f"Got {len(class_thresholds)} class thresholds, but {lcn} classes from the config"
 
         cm_plot            = confusion_matrix(y_hat_binary, self.Y_test, class_names)
         mcc_plot           = missed_class_confusion(y_hat_binary, self.Y_test, class_names)
@@ -99,10 +111,26 @@ class Report:
         f1_scores          = f_beta_scores(y_hat_binary, self.Y_test, class_names)
         roc_plot, roc_dict = roc_auc(y_hat, self.Y_test, class_names)
         # zip together the metric dicts
-        metrics: Dict = {class_names[i]:{'Threshold': class_thresholds[i]} for i in range(len(class_names))}
+        metrics: Dict = {class_names[i]:{'Threshold': class_thresholds[i]} for i in range(lcn)}
         for m in [rates, f1_scores, roc_dict]:
             for k, v in m.items():
                 metrics[k].update(v)
+
+        # Get the metrics for the fractional simulation results
+        self._fractional_simulation_test_dict['TPR'] = {}
+        self._fractional_simulation_test_dict['FPR'] = {}
+        for i, thresh in enumerate(class_thresholds):
+            class_name = class_names[i]
+            self._fractional_simulation_test_dict['TPR'][class_name] = {}
+            self._fractional_simulation_test_dict['FPR'][class_name] = {}
+            for f in self.fractional_simulation_test_results:
+                if f.class_id != i:
+                    continue
+                f_y_hat_binary = (f.y_hat >= torch.tensor(thresh, device=f.y_hat.device, dtype=f.y_hat.dtype)).to(torch.long)
+                rates = tpr_fpr(f_y_hat_binary, f.y, class_names)[class_name]
+                rname = f'{f.range_low} - {f.range_high} %'
+                self._fractional_simulation_test_dict['TPR'][class_name][rname] = rates['TPR']
+                self._fractional_simulation_test_dict['FPR'][class_name][rname] = rates['FPR']
 
         self.test_figures.extend([cm_plot, mcc_plot, roc_plot])
         if self.test_metric_table is None:
@@ -116,4 +144,11 @@ class Report:
         json_path = pdf_path.replace('.pdf', '.json')
         generate_pdf_report(self, pdf_path)
         generate_json_report(self, json_path)
+
+
+    def append_fractional_simulation_result(self, f: ForcedFractionSimulation, y_hat: Tensor):
+        if f.latest_simulation_labels is None:
+            raise RuntimeWarning("Cannot associate proper simulation labels to append results data")
+        fr = FractionalSimulationResult(f.ranges[f.range_idx][0], f.ranges[f.range_idx][1], f.class_idx, y_hat, f.latest_simulation_labels)
+        self.fractional_simulation_test_results.append(fr)
 

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -128,7 +128,7 @@ class Report:
                     continue
                 f_y_hat_binary = (f.y_hat >= torch.tensor(thresh, device=f.y_hat.device, dtype=f.y_hat.dtype)).to(torch.long)
                 rates = tpr_fpr(f_y_hat_binary, f.y, class_names)[class_name]
-                rname = f'{f.range_low} - {f.range_high} %'
+                rname = f'{f.range_low*100} - {f.range_high*100} %'
                 self._fractional_simulation_test_dict['TPR'][class_name][rname] = rates['TPR']
                 self._fractional_simulation_test_dict['FPR'][class_name][rname] = rates['FPR']
 

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -41,8 +41,8 @@ class ModelConfig:
 
 @dataclass
 class FractionalSimulationResult:
-    range_low: int
-    range_high: int
+    range_low: float
+    range_high: float
     class_id: int
     y_hat: Tensor
     y: Tensor

--- a/src/cover_class/simulation/__init__.py
+++ b/src/cover_class/simulation/__init__.py
@@ -4,6 +4,7 @@ from cover_class.simulation.simulate import (
 from cover_class.simulation.args import (
     SimulationArgs, 
     DataArgs,
+    ForceFracRange,
     args_from_config,
 )
 from cover_class.simulation.sim_utils import one_hot_encode_simulated_data
@@ -13,5 +14,6 @@ __all__ = [
     "args_from_config",
     "SimulationArgs",
     "DataArgs",
+    "ForceFracRange",
     "one_hot_encode_simulated_data"
 ]

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -66,5 +66,5 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
 
 @dataclass
 class ForceFracRange:
-    low: int
-    high: int
+    low: float
+    high: float

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple, Dict
 import numpy as np
 from torch import FloatTensor, Tensor
 import torch
+from dataclasses import dataclass
 
 from cover_class.utils import read_config
 
@@ -62,3 +63,8 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         real_labels = labels
     )
     return s, d
+
+@dataclass
+class ForceFracRange:
+    low: int
+    high: int

--- a/src/cover_class/simulation/force_fractions.py
+++ b/src/cover_class/simulation/force_fractions.py
@@ -1,0 +1,50 @@
+from typing import Tuple, List, Optional
+from collections.abc import Iterator
+from torch import Tensor, FloatTensor, LongTensor
+from torch.utils.data import DataLoader
+from copy import deepcopy
+
+from cover_class.simulation import ForceFracRange, run_simulation
+from cover_class.dataloader import OrchestratorDataset
+from cover_class.simulation import DataArgs, SimulationArgs
+
+class ForcedFractionSimulation(Iterator):
+    sim_args: SimulationArgs
+    data_args: DataArgs
+    num_classes: int
+    range_idx: int = -1
+    class_idx: int = 0
+    latest_simulation_labels: Optional[LongTensor] = None
+
+    def __init__(self, 
+            dataloader: DataLoader, 
+            test_spectra: FloatTensor,
+            test_labels: Tensor,
+            n_rows: int,
+            ranges: List[Tuple[int, int]]
+        ) -> None:
+        ods: OrchestratorDataset = dataloader.dataset # type: ignore
+        self.sim_args: SimulationArgs = deepcopy(ods.args.sim_config_args) # type: ignore
+        self.sim_args.n_iters = n_rows
+        self.data_args = DataArgs(test_spectra, test_labels)
+
+        self.num_classes = ods.args.num_classes
+        self.ranges = ranges
+    
+    def __next__(self) -> Tuple[FloatTensor, LongTensor]:
+        self.range_idx += 1
+        if self.range_idx == len(self.ranges):
+            self.class_idx += 1
+            self.range_idx = 0
+        if self.class_idx == self.num_classes:
+            raise StopIteration()
+                
+        simulation_data, simulation_labels, _ = run_simulation(
+            self.sim_args, 
+            self.data_args, 
+            self.data_args.real_spectra.device, 
+            self.class_idx, 
+            ForceFracRange(*self.ranges[self.range_idx])
+        )
+        self.latest_simulation_labels = simulation_labels
+        return simulation_data, simulation_labels

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -15,12 +15,34 @@ import torch.nn.functional as F
 from torch.distributions.dirichlet import Dirichlet
 from torch import device as Device
 
-from cover_class.simulation.args import SimulationArgs, DataArgs
+from cover_class.simulation.args import SimulationArgs, DataArgs, ForceFracRange
 
 
 # The masked out alpha value will be 2^-126, the IEEE 754 smallest positive float32 value
 ALPHA_MASKOUT_VALUE = torch.tensor(2 ** -126, dtype=torch.float32)
 NULL_CLASS_VALUE = -1
+
+def force_fractions(dirich_fractions: FloatTensor, force_frac_range: Optional[ForceFracRange], force_class: Optional[int], classes: CharTensor, cumsum_n_components: LongTensor) -> FloatTensor:
+    if force_frac_range is None or force_class is None:
+        return dirich_fractions
+
+    # 1. get the index of the force class from comparing classes to cumsum_n_components
+    rows = torch.arange(dirich_fractions.shape[0], device=dirich_fractions.device)
+    fcol = (classes == force_class).long().argmax(1)
+    fidx = cumsum_n_components.gather(1, (fcol + 1).unsqueeze(1)).squeeze(1) - 1  # component idx 
+
+    # 2. get the current dirich_fractions values at the indices and random uniform draw from the force_frac_range
+    old  = dirich_fractions[rows, fidx]
+    new  = (force_frac_range.low + (force_frac_range.high - force_frac_range.low) * torch.rand_like(old)).clamp_(0, 1)
+
+    # 5. return the newly adjusted fractions
+    other = 1 - old
+    ok = other > 0
+    dirich_fractions[~ok] = 0.0
+    dirich_fractions[rows[~ok], fidx[~ok]] = 1
+    dirich_fractions[ok] = dirich_fractions[ok] * (((1 - new[ok]) / other[ok]).unsqueeze(1))
+    dirich_fractions[rows[ok], fidx[ok]] = new[ok]
+    return dirich_fractions
 
 
 def reduce_between(mask: BoolTensor, cumsum_n_components: LongTensor) -> ShortTensor:
@@ -35,7 +57,9 @@ def reduce_between(mask: BoolTensor, cumsum_n_components: LongTensor) -> ShortTe
 def run_simulation(
         sim_args:  SimulationArgs, 
         data_args: DataArgs, 
-        device:    Device = Device("cpu")
+        device:    Device = Device("cpu"),
+        force_class: Optional[int] = None,
+        force_frac_range: Optional[ForceFracRange] = None,
     
     ) -> Tuple[FloatTensor, LongTensor, Optional[FloatTensor]]:
 
@@ -43,7 +67,7 @@ def run_simulation(
     data_args.to(device)
 
     with torch.no_grad():
-        classes, cumsum_n_components = _0_init_simulation_state(sim_args, device)
+        classes, cumsum_n_components = _0_init_simulation_state(sim_args, device, force_class)
 
         simulation_space_size = (sim_args.n_iters, int(cumsum_n_components.max().item()))
         alpha = _1_generate_alpha(
@@ -60,6 +84,7 @@ def run_simulation(
         del alpha
 
         dirich_fractions = _3_remove_small_fractions(dirich_fractions, mask)
+        dirich_fractions = force_fractions(dirich_fractions, force_frac_range, force_class, classes, cumsum_n_components)
         
         filtered_n_components_per_class = reduce_between(mask, cumsum_n_components)
         # if there are classes that're no longer present after the filtering, replace them with `NULL_CLASS_VALUE`
@@ -102,8 +127,9 @@ def run_simulation(
 
 
 def _0_init_simulation_state(
-        sim_args: SimulationArgs,
-        device:   Device
+        sim_args:    SimulationArgs,
+        device:      Device,
+        force_class: Optional[int] = None,
 
     ) -> Tuple[
         CharTensor, # classes
@@ -119,12 +145,20 @@ def _0_init_simulation_state(
     )
 
     n_components_numpy: npt.NDArray[np.int32] = np.random.choice(sim_args.n_components, size, replace=True).astype(np.int32)
+    n_components = torch.from_numpy(n_components_numpy).to(dtype=torch.int64, device=device)
 
-    cumsum_n_components = (torch.
-        from_numpy(n_components_numpy).to(dtype=torch.int64, device=device).
-        cumsum_(dim=1)
-    )
-    cumsum_n_components = F.pad(cumsum_n_components, (1, 0), value=0)  # pad left size with zeros
+    if force_class is not None:
+        # Add in the force class to every row
+        missing = ~(classes == force_class).any(dim=1)
+        if missing.any():
+            cols = torch.randint(low=0, high=size[1], size=(int(missing.sum().item()),), device=device)
+            rows = missing.nonzero(as_tuple=False).squeeze(1)
+            classes[rows, cols] = force_class
+        
+        # And force it to have 1 component (only draw 1 real sample)
+        n_components[(classes == force_class)] = 1
+
+    cumsum_n_components = F.pad(n_components.cumsum_(dim=1), (1, 0), value=0)  # pad left size with zeros
 
     return classes, cumsum_n_components # type: ignore[return-value]
 
@@ -179,6 +213,7 @@ def _3_remove_small_fractions(
 
     # now we need to align the matrix again
     return dirich_fractions.gather(1, (dirich_fractions != 0).int().argsort(descending=True)) # type: ignore[return-value]
+
 
 def _4_stratified_split(
         filtered_n_components_per_class: ShortTensor, 

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -35,7 +35,7 @@ def force_fractions(dirich_fractions: FloatTensor, force_frac_range: Optional[Fo
     old  = dirich_fractions[rows, fidx]
     new  = (force_frac_range.low + (force_frac_range.high - force_frac_range.low) * torch.rand_like(old)).clamp_(0, 1)
 
-    # 5. return the newly adjusted fractions
+    # 3. return the newly adjusted fractions
     other = 1 - old
     ok = other > 0
     dirich_fractions[~ok] = 0.0

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -4,7 +4,8 @@ import torch
 from torch import Tensor
 
 from cover_class.simulation import simulate # type: ignore[import]
-from cover_class.simulation import SimulationArgs, DataArgs
+from cover_class.simulation import SimulationArgs, DataArgs, ForceFracRange
+from cover_class.simulation.simulate import force_fractions, _0_init_simulation_state # type: ignore[import]
 
 RANDOM_SEED = 42
 
@@ -94,7 +95,7 @@ class simulationTest(unittest.TestCase):
             classes, cumsum_n_components = simulate._0_init_simulation_state(sim_args, None)
             expected_size = (sim_args.n_iters, int(cumsum_n_components.max().item()))
 
-            def mock_init_simulation_state(_: SimulationArgs, __):
+            def mock_init_simulation_state(_: SimulationArgs, __, ___):
                 return classes, cumsum_n_components
             
             def mock_alpha(size, c, a, al, au):
@@ -143,7 +144,7 @@ class simulationTest(unittest.TestCase):
             classes, cumsum_n_components = simulate._0_init_simulation_state(sim_args, None)
             m = int(cumsum_n_components.max().item())
 
-            def mock_init_simulation_state(_: SimulationArgs, __):
+            def mock_init_simulation_state(_: SimulationArgs, __, ___):
                 return classes, cumsum_n_components
 
             def mock_dirichlet(alpha, min_frac):
@@ -234,7 +235,7 @@ class simulationTest(unittest.TestCase):
             classes = torch.tensor([[1, 2]], dtype=torch.int8)
             cumsum_n_components = torch.tensor([[1, 3]], dtype=torch.int32)
 
-            def mock_init_sim_state(_: SimulationArgs, __):
+            def mock_init_sim_state(_: SimulationArgs, __, ___):
                 return classes, cumsum_n_components
             
             captured = {"filtered_n_components_per_class": None, "classes": None, "labels": None, "n_classes": None,
@@ -377,7 +378,68 @@ class simulationTest(unittest.TestCase):
 
         torch.testing.assert_close(out, expected, rtol=0, atol=1e-7)
 
+
+    def test_force_fractions(self):
+        torch.manual_seed(0)
+
+        n_iters = 32
+        n_sub   = 4
+        max_comp = 16
+        force_class = 7
+
+        force_frac_range = ForceFracRange(0.70, 0.90)
+
+        classes = torch.randint(0, 20, (n_iters, n_sub), dtype=torch.int8)
+        classes[(classes==force_class)] = force_class+1
+        classes[:, 0] = force_class
+
+        n_components = torch.ones((n_iters, n_sub), dtype=torch.long)
+        cumsum = torch.nn.functional.pad(n_components.cumsum(dim=1), (1, 0), value=0)  # (n_iters, n_sub+1)
+
+        # dirich_fractions: per row, put mass only in the first n_sub entries, rest zero, normalized
+        dirich = torch.rand((n_iters, max_comp), dtype=torch.float32)
+        dirich[:, n_sub:] = 0.0
+        dirich = dirich / dirich.sum(dim=1, keepdim=True)
+
+        out = force_fractions(dirich, force_frac_range, force_class, classes, cumsum)
+
+        self.assertTrue(torch.allclose(out.sum(dim=1), torch.ones(n_iters), atol=1e-5))
+
+        rows = torch.arange(n_iters)
+        fcol = (classes == force_class).long().argmax(1)
+        fidx = cumsum.gather(1, (fcol + 1).unsqueeze(1)).squeeze(1) - 1
+        fvals = out[rows, fidx]
+
+        self.assertTrue(bool((fvals >= force_frac_range.low - 1e-6).all()))
+        self.assertTrue(bool((fvals <= force_frac_range.high + 1e-6).all()))
+        self.assertTrue(bool((out >= -1e-7).all()))
+
+
+    def test_0_init_simulation_state_force_class(self):
+        torch.manual_seed(0)
+
+        class SimArgs:
+            def __init__(self):
+                self.n_iters = 64
+                self.n_classes_in_subsets = 6
+                self.n_classes = 50
+                self.n_components = [0, 1, 2, 3, 4]
+
+        sim_args = SimArgs()
+        device = torch.device("cpu")
+        force_class = 7
+
+        classes, cumsum = _0_init_simulation_state(sim_args, device, force_class)
+
+        # force_class appears exactly once per row in classes
+        counts = (classes == force_class).sum(dim=1)
+        self.assertTrue(bool((counts == 1).all()))
+
+        # force_class has a value of 1 for cumsum_n_components
+        n_components = cumsum[:, 1:] - cumsum[:, :-1]
+
+        self.assertTrue(bool((n_components[classes == force_class] == 1).all()))
+
+
 if __name__ == "__main__":
-    # unittest.main()
-    s = simulationTest()
-    s.test_get_fractions_by_class()
+    unittest.main()


### PR DESCRIPTION
## Overview
This PR adds in the functionality for:
A. Forcing the fractional contributions of a specific class to a simulated set to be in a certain range. 
B. Creating a reporting method for obtaining the model's posteriors on the fractional simulation set, and then generating a report from it

Please see the models/training_example.py script for how to use it

## Related Tickets

## Testing
#### Unit Tests
Added a new set of unit tests and verified they pass with `make test`

#### Smoke Test
Generated report output:
<img width="1000" height="819" alt="Screenshot 2026-01-13 at 10 54 19 AM" src="https://github.com/user-attachments/assets/7fe7e439-0748-4810-bbab-c3ecf34518ca" />

