### PR TITLE
OOD Test Set

### DIFF
--- a/models/training_example.py
+++ b/models/training_example.py
@@ -111,6 +111,8 @@ def run_pipeline_classifier(
 
     ## create the OOD test set
     ood_test_set_x, ood_test_set_y = ood_test_set_from_config(config)
+    ood_test_set_x = torch.rand((len(ood_test_set_y), simulation_x_test.shape[1])) # NOTE: This is only to force an example
+    assert ood_test_set_x.shape[-1] == simulation_x_test.shape[-1], "Mismatched test set shapes"
 
     class MultiLabelClassifier(nn.Module):
         def __init__(self, input_dim, num_classes):

--- a/models/training_example.py
+++ b/models/training_example.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 from cover_class.train import setup_training_from_config, make_simulation_test_set, make_run_name #type: ignore
 from cover_class.static.retrieval import generate_hdf5_from_config #type: ignore
 from cover_class.utils import seed as sseed #type: ignore
+from cover_class.utils import ood_test_set_from_config # type: ignore
 from cover_class.reporting import ModelConfig, Report #type: ignore
 
 ENV_VAR_PREFIX = 'COVER_CLASS_TRAIN_'
@@ -108,6 +109,9 @@ def run_pipeline_classifier(
     sseed(seed)
     simulation_x_test, simulation_y_test, _ = make_simulation_test_set(dataloader, test_X, test_Y, simulated_test_set_size)
 
+    ## create the OOD test set
+    ood_test_set_x, ood_test_set_y = ood_test_set_from_config(config)
+
     class MultiLabelClassifier(nn.Module):
         def __init__(self, input_dim, num_classes):
             super().__init__()
@@ -156,6 +160,7 @@ def run_pipeline_classifier(
             },
         ),
         Y_test=simulation_y_test,
+        Y_ood_test=ood_test_set_y,
         random_seed=seed,
         run_name=run_name,
     )
@@ -194,8 +199,9 @@ def run_pipeline_classifier(
     ## Finally, generate the report
     with torch.no_grad():
         y_hat = torch.sigmoid(model(simulation_x_test))
+        y_hat_ood = torch.sigmoid(model(ood_test_set_x))
     thresholds = [0.5] * y_hat.shape[-1]
-    report.make_report(y_hat, thresholds)
+    report.make_report(y_hat, thresholds, y_hat_ood)
 
 if __name__ == "__main__": 
     run_pipeline_classifier()

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -13,6 +13,7 @@ datasets:
   ash+char:
   snow+ice:
   water:
+ood-test-set: /some/path.hdf5
 simulation:
   n_components: [1,5]
   n_classes_in_subsets: 3

--- a/src/cover_class/reporting/json_report.py
+++ b/src/cover_class/reporting/json_report.py
@@ -16,6 +16,7 @@ def generate_json_report(
     out.update({'Notes':report_config.notes})
     out.update({'Train':report_config.train_metric_table})
     out.update({'Test':report_config.test_metric_table})
+    out.update({'OOD Test':report_config.ood_test_metric_table})
     out.update({'Model':
         {
             'Name':report_config.model_config.model_name,

--- a/src/cover_class/reporting/pdf_report.py
+++ b/src/cover_class/reporting/pdf_report.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Dict, TYPE_CHECKING
+from typing import Any, List, Dict, Optional, TYPE_CHECKING
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
@@ -20,7 +20,7 @@ from reportlab.platypus import ( # type: ignore[import]
     Image,
     PageBreak,
 )
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle # type: ignore[import]
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle, StyleSheet1 # type: ignore[import]
 from reportlab.lib.units import inch # type: ignore[import]
 
 from cover_class.reporting.utils import inference_over_scene, rgb_from_scene
@@ -148,6 +148,39 @@ def _add_styles():
     return styles
 
 
+def add_section(
+        fn: int, 
+        contents: List[Any], 
+        metric_table: Optional[dict], 
+        plots: List[GenLinePlot], 
+        figures: List[Figure], 
+        report_styles: StyleSheet1, 
+        title: str
+    ) -> int:
+
+    contents.append(Paragraph(f"{title} Report", report_styles["Heading1"]))
+    contents.append(Spacer(1, 0.1 * inch))
+    if metric_table:
+        _metrics_table(contents, report_styles, metric_table, f"{title} Metrics")
+        contents.append(Spacer(1, 0.1 * inch))
+    contents.append(Paragraph(f"{title} Plots", report_styles["Heading2"]))
+    contents.append(Spacer(1, 0.1 * inch))
+
+    for i, glp in enumerate(plots, start=1):
+        fn += 1
+        fig = _genlineplot_to_figure(glp)
+        contents.extend(_figure_to_image_contents(fig, report_styles, caption=f"[{title}] Figure {fn}: {glp.title}"))
+        contents.append(Spacer(1, 0.1 * inch))
+        plt.close(fig)
+
+    for i, fig in enumerate(figures, start=1):
+        fn += 1
+        contents.extend(_figure_to_image_contents(fig, report_styles, caption=f"[{title}] Figure {fn}"))
+        contents.append(Spacer(1, 0.5 * inch))
+    contents.append(PageBreak())
+    return fn
+
+
 def generate_pdf_report(
     report_config: "Report",
     pdf_path: str
@@ -214,51 +247,16 @@ def generate_pdf_report(
 
 
     ############### Training report: ##############
-    fn = 0
-    contents.append(Paragraph("Training Report", report_styles["Heading1"]))
-    contents.append(Spacer(1, 0.1 * inch))
-    if report_config.train_metric_table:
-        _metrics_table(contents, report_styles, report_config.train_metric_table, "Training Metrics")
-        contents.append(Spacer(1, 0.1 * inch))
-    contents.append(Paragraph("Training Plots", report_styles["Heading2"]))
-    contents.append(Spacer(1, 0.1 * inch))
-
-    for i, glp in enumerate(report_config.train_plots, start=1):
-        fn += 1
-        fig = _genlineplot_to_figure(glp)
-        contents.extend(_figure_to_image_contents(fig, report_styles, caption=f"[Train] Figure {fn}: {glp.title}"))
-        contents.append(Spacer(1, 0.1 * inch))
-        plt.close(fig)
-
-    for i, fig in enumerate(report_config.train_figures, start=1):
-        fn += 1
-        contents.extend(_figure_to_image_contents(fig, report_styles, caption=f"[Train] Figure {fn}"))
-        contents.append(Spacer(1, 0.5 * inch))
-    contents.append(PageBreak())
+    fn = add_section(0, contents, report_config.train_metric_table, report_config.train_plots, report_config.train_figures, report_styles, "Train")
     ###############################################
 
 
     ############### Testing report: ###############
-    contents.append(Paragraph("Testing Report", report_styles["Heading1"]))
-    contents.append(Spacer(1, 0.1 * inch))
-    if report_config.test_metric_table:
-        _metrics_table(contents, report_styles, report_config.test_metric_table, "Test Metrics")
-        contents.append(Spacer(1, 0.1 * inch))
-    contents.append(Paragraph("Testing Plots", report_styles["Heading2"]))
-    contents.append(Spacer(1, 0.1 * inch))
+    fn = add_section(fn, contents, report_config.test_metric_table, report_config.test_plots, report_config.test_figures, report_styles, "Test")
+    ###############################################
 
-    for i, glp in enumerate(report_config.test_plots, start=1):
-        fn += 1
-        fig = _genlineplot_to_figure(glp)
-        contents.extend(_figure_to_image_contents(fig, report_styles, caption=f"[Test] Figure {fn}: {glp.title}"))
-        contents.append(Spacer(1, 0.1 * inch))
-        plt.close(fig)
-
-    for i, fig in enumerate(report_config.test_figures, start=1):
-        fn += 1
-        contents.extend(_figure_to_image_contents(fig, report_styles, caption=f"[Test] Figure {fn}"))
-        contents.append(Spacer(1, 0.5 * inch))
-    contents.append(PageBreak())
+    ############### OOD Testing report: ###############
+    fn = add_section(fn, contents, report_config.ood_test_metric_table, report_config.ood_test_plots, report_config.ood_test_figures, report_styles, "OOD Test")
     ###############################################
 
 

--- a/src/cover_class/reporting/pdf_report.py
+++ b/src/cover_class/reporting/pdf_report.py
@@ -152,7 +152,7 @@ def add_section(
         fn: int, 
         contents: List[Any], 
         metric_table: Optional[dict], 
-        plots: List[GenLinePlot], 
+        plots: List[Any], 
         figures: List[Figure], 
         report_styles: StyleSheet1, 
         title: str

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -65,6 +65,10 @@ class Report:
     _download_missing_qualitative_testing_scenes_from_config: bool = True
 
     def __post_init__(self):
+        if self.Y_ood_test is not None:
+            a,b = self.Y_test.shape[1], self.Y_ood_test.shape[1]
+            assert a == b, f"Got mismatched number of classes for Y_test ({a}) and Y_ood_test ({b})"
+
         if self.timestamp is None:
             self.timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
         if isinstance(self.config, str):
@@ -84,10 +88,14 @@ class Report:
             self.qualitative_testing_scenes_paths.extend(download_scenes(uris))
 
     def make_report(self, y_hat: Tensor, class_thresholds: List[float], y_hat_ood_test: Optional[Tensor] = None):
-        self.generate_metrics(self.Y_test, y_hat, class_thresholds, self.test_figures, self.test_metric_table)
+        if self.test_metric_table is None:
+            self.test_metric_table = {}
+        if self.ood_test_metric_table is None:
+            self.ood_test_metric_table = {}
+        self.test_metric_table.update(self.generate_metrics(self.Y_test, y_hat, class_thresholds, self.test_figures))
         if y_hat_ood_test is not None:
             assert self.Y_ood_test is not None, "Got probabilities for OOD Test set, but no labels were provided"
-            self.generate_metrics(self.Y_ood_test, y_hat_ood_test, class_thresholds, self.ood_test_figures, self.ood_test_metric_table)
+            self.ood_test_metric_table.update(self.generate_metrics(self.Y_ood_test, y_hat_ood_test, class_thresholds, self.ood_test_figures))
 
         # 2. Generate Report
         os.makedirs(self.outdir, exist_ok=True)
@@ -97,7 +105,7 @@ class Report:
         generate_pdf_report(self, pdf_path)
         generate_json_report(self, json_path)
 
-    def generate_metrics(self, y: Union[Tensor, NDArray], y_hat: Tensor, class_thresholds: List[float], figure_list: List[Figure], metric_table: Optional[dict]) -> None:
+    def generate_metrics(self, y: Union[Tensor, NDArray], y_hat: Tensor, class_thresholds: List[float], figure_list: List[Figure]) -> dict:
         assert len(class_thresholds) == y_hat.shape[-1], f"Got {len(class_thresholds)} thresholds for {y_hat.shape[-1]} classes"
 
         y_hat_binary = (y_hat >= torch.tensor(class_thresholds, device=y_hat.device, dtype=y_hat.dtype)).to(torch.long)
@@ -123,7 +131,5 @@ class Report:
                 metrics[k].update(v)
 
         figure_list.extend([cm_plot, mcc_plot, roc_plot])
-        if metric_table is None:
-            metric_table = {}
-        metric_table.update(metrics)
+        return metrics
 

--- a/src/cover_class/reporting/report_config.py
+++ b/src/cover_class/reporting/report_config.py
@@ -45,12 +45,16 @@ class Report:
     model_config: ModelConfig
     Y_test: Union[Tensor, NDArray]
 
+    Y_ood_test: Optional[Union[Tensor, NDArray]] = None
     train_plots: List[GenLinePlot] = field(default_factory=list)
     test_plots: List[GenLinePlot] = field(default_factory=list)
+    ood_test_plots: List[GenLinePlot] = field(default_factory=list)
     train_figures: List[Figure] = field(default_factory=list)
     test_figures: List[Figure] = field(default_factory=list)
+    ood_test_figures: List[Figure] = field(default_factory=list)
     train_metric_table: Optional[dict] = None
     test_metric_table: Optional[dict] = None
+    ood_test_metric_table: Optional[dict] = None
     author: Optional[str] = None
     wandb_link: Optional[str] = None
     random_seed: Optional[int] = None
@@ -79,7 +83,21 @@ class Report:
             uris = read_config(self.config).get("test-scene-urls", [])
             self.qualitative_testing_scenes_paths.extend(download_scenes(uris))
 
-    def make_report(self, y_hat: Tensor, class_thresholds: List[float]):
+    def make_report(self, y_hat: Tensor, class_thresholds: List[float], y_hat_ood_test: Optional[Tensor] = None):
+        self.generate_metrics(self.Y_test, y_hat, class_thresholds, self.test_figures, self.test_metric_table)
+        if y_hat_ood_test is not None:
+            assert self.Y_ood_test is not None, "Got probabilities for OOD Test set, but no labels were provided"
+            self.generate_metrics(self.Y_ood_test, y_hat_ood_test, class_thresholds, self.ood_test_figures, self.ood_test_metric_table)
+
+        # 2. Generate Report
+        os.makedirs(self.outdir, exist_ok=True)
+        rn = self.run_name if self.run_name else str(self.timestamp).replace(":", "-")
+        pdf_path = os.path.join(self.outdir, f"{self.model_config.model_name}_{rn}.pdf")
+        json_path = pdf_path.replace('.pdf', '.json')
+        generate_pdf_report(self, pdf_path)
+        generate_json_report(self, json_path)
+
+    def generate_metrics(self, y: Union[Tensor, NDArray], y_hat: Tensor, class_thresholds: List[float], figure_list: List[Figure], metric_table: Optional[dict]) -> None:
         assert len(class_thresholds) == y_hat.shape[-1], f"Got {len(class_thresholds)} thresholds for {y_hat.shape[-1]} classes"
 
         y_hat_binary = (y_hat >= torch.tensor(class_thresholds, device=y_hat.device, dtype=y_hat.dtype)).to(torch.long)
@@ -93,27 +111,19 @@ class Report:
         assert y_hat.shape[-1] == len(class_names), f"Got {y_hat.shape[-1]} classes in y_hat, but {len(class_names)} classes from the config"
         assert len(class_thresholds) == len(class_names), f"Got {len(class_thresholds)} class thresholds, but {len(class_names)} classes from the config"
 
-        cm_plot            = confusion_matrix(y_hat_binary, self.Y_test, class_names)
-        mcc_plot           = missed_class_confusion(y_hat_binary, self.Y_test, class_names)
-        rates              = tpr_fpr(y_hat_binary, self.Y_test, class_names)
-        f1_scores          = f_beta_scores(y_hat_binary, self.Y_test, class_names)
-        roc_plot, roc_dict = roc_auc(y_hat, self.Y_test, class_names)
+        cm_plot            = confusion_matrix(y_hat_binary, y, class_names)
+        mcc_plot           = missed_class_confusion(y_hat_binary, y, class_names)
+        rates              = tpr_fpr(y_hat_binary, y, class_names)
+        f1_scores          = f_beta_scores(y_hat_binary, y, class_names)
+        roc_plot, roc_dict = roc_auc(y_hat, y, class_names)
         # zip together the metric dicts
         metrics: Dict = {class_names[i]:{'Threshold': class_thresholds[i]} for i in range(len(class_names))}
         for m in [rates, f1_scores, roc_dict]:
             for k, v in m.items():
                 metrics[k].update(v)
 
-        self.test_figures.extend([cm_plot, mcc_plot, roc_plot])
-        if self.test_metric_table is None:
-            self.test_metric_table = {}
-        self.test_metric_table.update(metrics)
-
-        # 2. Generate Report
-        os.makedirs(self.outdir, exist_ok=True)
-        rn = self.run_name if self.run_name else str(self.timestamp).replace(":", "-")
-        pdf_path = os.path.join(self.outdir, f"{self.model_config.model_name}_{rn}.pdf")
-        json_path = pdf_path.replace('.pdf', '.json')
-        generate_pdf_report(self, pdf_path)
-        generate_json_report(self, json_path)
+        figure_list.extend([cm_plot, mcc_plot, roc_plot])
+        if metric_table is None:
+            metric_table = {}
+        metric_table.update(metrics)
 

--- a/src/cover_class/utils.py
+++ b/src/cover_class/utils.py
@@ -37,16 +37,16 @@ def load_rfl(hdr_fp:str) -> Tuple[np.ndarray, np.ndarray]:
 
 def ood_test_set_from_config(c: str|Dict, include_unknown: bool = False, err_on_missed_class: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
     config = read_config(c)
-    class_order: List[str] = config['datasets'].keys()
+    class_order: List[str] = [d for d in config['datasets'].keys() if config['datasets'][d] is not None]
 
     with h5py.File(config['ood-test-set'], 'r') as f:
-        labels  = np.asarray(f['labels'])
-        classes = np.asarray(f.attrs['classes']).astype(str) # type: ignore
+        labels  = np.asarray(f['labels'][:])
+        classes = np.asarray(f.attrs['classes'][:]).astype(str) # type: ignore
 
         present = (labels != 0) if include_unknown else (labels != 0) & (labels != 2)
         idx = {c: j for j, c in enumerate(classes)}
 
-        X = torch.from_numpy(f['spectra']).to(torch.float32)
+        X = torch.from_numpy(f['spectra'][:]).to(torch.float32)
         Y = np.zeros((labels.shape[0], len(class_order)), dtype=np.uint8)
         for i, name in enumerate(class_order):
             Y[:, i] = present[:, idx[name]].astype(np.uint8)

--- a/src/cover_class/utils.py
+++ b/src/cover_class/utils.py
@@ -1,10 +1,11 @@
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List
 import yaml # type: ignore[import]
 import torch
 import numpy as np
 import random
 from spectral.io import envi # type: ignore[import]
 import re
+import h5py # type: ignore[import]
 
 def read_config(path: str|Dict) -> Dict: 
     if isinstance(path, dict): return path
@@ -33,3 +34,22 @@ def load_rfl(hdr_fp:str) -> Tuple[np.ndarray, np.ndarray]:
     banddef = [name_to_nm(name) for name in rfl_header.metadata['wavelength']]
     banddef = np.array(banddef, dtype=float) # type: ignore 
     return rfl, banddef # type: ignore 
+
+def ood_test_set_from_config(c: str|Dict, include_unknown: bool = False, err_on_missed_class: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
+    config = read_config(c)
+    class_order: List[str] = config['datasets'].keys()
+
+    with h5py.File(config['ood-test-set'], 'r') as f:
+        labels  = np.asarray(f['labels'])
+        classes = np.asarray(f.attrs['classes']).astype(str) # type: ignore
+
+        present = (labels != 0) if include_unknown else (labels != 0) & (labels != 2)
+        idx = {c: j for j, c in enumerate(classes)}
+
+        X = torch.from_numpy(f['spectra']).to(torch.float32)
+        Y = np.zeros((labels.shape[0], len(class_order)), dtype=np.uint8)
+        for i, name in enumerate(class_order):
+            Y[:, i] = present[:, idx[name]].astype(np.uint8)
+            if err_on_missed_class and Y[:, i].sum() == 0:
+                raise RuntimeError(f"No data is found in the OOD Test set for class: '{name}'")
+        return X, torch.from_numpy(Y).to(torch.long)


### PR DESCRIPTION
## Overview

This PR adds in the ability to include an OOD Test HDF5. The format of the OOD Test set is based on what @marchett2 provided

#### PDF File:
<img width="725" height="770" alt="Screenshot 2026-01-28 at 4 02 16 PM" src="https://github.com/user-attachments/assets/cc3cd15b-e1ce-4b32-a56d-1a7003a878ac" />

#### JSON File:
```
    "OOD Test": {
        "soil": {
            "Threshold": 0.5,
            "TPR": 0.392,
            "FPR": 0.395,
            "F-1.0 Score": 0.332,
            "ROC-AUC": 0.5
        },
        "ash+char": {
            "Threshold": 0.5,
            "TPR": 0.081,
            "FPR": 0.085,
            "F-1.0 Score": 0.088,
            "ROC-AUC": 0.502
        },
        "snow+ice": {
            "Threshold": 0.5,
            "TPR": 0.615,
            "FPR": 0.615,
            "F-1.0 Score": 0.321,
            "ROC-AUC": 0.502
        }
    },
```

## Testing
Run the below command with a valid validation and simulation set:
```
(emit-fc) makiper@MT-400290 cover-class % python3 models/training_example.py --outdir . --config config/dataloader\ copy.yml --lr 0.0001 --batch-size 1024 --max-training-steps 100 --log-interval 20 --simulated-test-set-size 1000 --seed 42
```

It should output a correct PDF and JSON file showing the training and test metrics and figures.