### PR TITLE
Glint Scalar

### DIFF
--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -24,6 +24,8 @@ simulation:
   white_noise: 0.0001
   noise_covariance_csv: static/spectral_noise_covariances.csv
   return_fractions: false
+  glint_upper_scalar:
+  glint_lower_scalar:
 subsample:
   test-fraction: 0.2
   selected-method: convex-hull

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -19,6 +19,8 @@ class SimulationArgs(Struct):
     white_noise: float
     noise_covariance: Optional[FloatTensor]
     return_fractions: bool
+    glint_scalar_range: Tuple[Optional[float], Optional[float]]
+    water_classes: List[int]
 
     def to(self, device: torch.device):
         if self.noise_covariance is not None: 
@@ -56,6 +58,8 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         white_noise = sim_config['white_noise'],
         noise_covariance = FloatTensor(torch.from_numpy(noise_cov).to(torch.float32)) if noise_cov is not None else None,
         return_fractions=sim_config["return_fractions"],
+        glint_scalar_range=(sim_config["glint_lower_scalar"], sim_config["glint_upper_scalar"]),
+        water_classes=[i for i in range(len(config['datasets'])) if 'water' in list(config['datasets'].keys())[i].lower()],
     )
 
     d = DataArgs(

--- a/src/cover_class/simulation/force_fractions.py
+++ b/src/cover_class/simulation/force_fractions.py
@@ -4,7 +4,7 @@ from torch import Tensor, FloatTensor, LongTensor
 from torch.utils.data import DataLoader
 from copy import deepcopy
 
-from cover_class.simulation import ForceFracRange, run_simulation
+from cover_class.simulation import ForceFracRange, run_simulation, one_hot_encode_simulated_data
 from cover_class.dataloader import OrchestratorDataset
 from cover_class.simulation import DataArgs, SimulationArgs
 
@@ -15,13 +15,15 @@ class ForcedFractionSimulation(Iterator):
     range_idx: int = -1
     class_idx: int = 0
     latest_simulation_labels: Optional[LongTensor] = None
+    one_hot_encode: bool = True
 
     def __init__(self, 
             dataloader: DataLoader, 
             test_spectra: FloatTensor,
             test_labels: Tensor,
             n_rows: int,
-            ranges: List[Tuple[int, int]]
+            ranges: List[Tuple[int, int]],
+            one_hot_encode: bool = True
         ) -> None:
         ods: OrchestratorDataset = dataloader.dataset # type: ignore
         self.sim_args: SimulationArgs = deepcopy(ods.args.sim_config_args) # type: ignore
@@ -30,6 +32,7 @@ class ForcedFractionSimulation(Iterator):
 
         self.num_classes = ods.args.num_classes
         self.ranges = ranges
+        self.one_hot_encode = one_hot_encode
     
     def __next__(self) -> Tuple[FloatTensor, LongTensor]:
         self.range_idx += 1
@@ -46,5 +49,10 @@ class ForcedFractionSimulation(Iterator):
             self.class_idx, 
             ForceFracRange(*self.ranges[self.range_idx])
         )
+        if self.one_hot_encode:
+            simulation_labels = one_hot_encode_simulated_data(simulation_labels, self.num_classes) # type: ignore
+            self.latest_simulation_labels = simulation_labels
+            return simulation_data, simulation_labels
+        
         self.latest_simulation_labels = simulation_labels
         return simulation_data, simulation_labels

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -22,6 +22,25 @@ from cover_class.simulation.args import SimulationArgs, DataArgs, ForceFracRange
 ALPHA_MASKOUT_VALUE = torch.tensor(2 ** -126, dtype=torch.float32)
 NULL_CLASS_VALUE = -1
 
+def appy_water_scalar(data_args: DataArgs, glint_scalar_range: Tuple[Optional[float], Optional[float]], water_classes: List[int]) -> FloatTensor:
+    labels = data_args.real_labels
+    spectra = data_args.real_spectra
+
+    lo, hi = glint_scalar_range
+    if lo is None or hi is None or len(water_classes) == 0: 
+        return spectra
+    lo, hi = (hi, lo) if hi < lo else (lo, hi)
+
+    m = labels[..., None].eq(torch.as_tensor(water_classes, device=labels.device, dtype=labels.dtype)).any(-1)
+    if not m.any(): 
+        return spectra
+    
+    s = lo + (hi - lo) * torch.rand(spectra.size(0), device=spectra.device, dtype=spectra.dtype)
+    X = spectra.clone()
+    X[m] += s[m].unsqueeze(-1)
+    return FloatTensor(X)
+
+
 def force_fractions(dirich_fractions: FloatTensor, force_frac_range: Optional[ForceFracRange], force_class: Optional[int], classes: CharTensor, cumsum_n_components: LongTensor) -> FloatTensor:
     if force_frac_range is None or force_class is None:
         return dirich_fractions
@@ -66,6 +85,8 @@ def run_simulation(
     sim_args.to(device)
     data_args.to(device)
 
+    real_spectra = appy_water_scalar(data_args, sim_args.glint_scalar_range, sim_args.water_classes)
+
     with torch.no_grad():
         classes, cumsum_n_components = _0_init_simulation_state(sim_args, device, force_class)
 
@@ -101,7 +122,7 @@ def run_simulation(
         )
 
         resulting_real_spectra = _5_make_sim_spectra(
-            data_args.real_spectra,
+            real_spectra,
             selected_idxs, 
             spectra_mask, 
             dirich_fractions
@@ -111,7 +132,7 @@ def run_simulation(
         resulting_real_spectra += _6_add_noise(
             sim_args.noise_covariance,
             sim_args.n_iters,
-            data_args.real_spectra.shape[1], 
+            real_spectra.shape[1], 
             sim_args.white_noise,
             device
         )


### PR DESCRIPTION
## Overview
This PR adds in an optional glint scalar addition operation to the simulation set. If the user specifies the range in the config, it will be added to all classes that are labeled to include water - given if the `dataset` subitem has `water` in the class label of the yaml config file.

Example scalar additions:
```
  glint_upper_scalar: 0.25
  glint_lower_scalar: 0.1
```

The scalars for the water class are randomized per sample within the specified range. 