### PR TITLE
N Components Per Class

### DIFF
--- a/src/cover_class/config/README.md
+++ b/src/cover_class/config/README.md
@@ -27,6 +27,10 @@ datasets:
 ```
 version: <version of the config [string]>
 tags:    <various tags to descibe the config [list[string]]>
+drop-bands-wavelengths: <ranges of bands to drop [list[integer]]>
+  - [400, 500]
+  - [1000, 1200]
+ood-test-set: <paths to OOD test HDF5 [string]>
 datasets:
   soil:     <paths to datasets [list[string]]>
   pv:       <paths to datasets [list[string]]>
@@ -35,14 +39,25 @@ datasets:
   snow+ice: <paths to datasets [list[string]]>
   water:    <paths to datasets [list[string]]>
 simulation:
-  n_components:         <possible numer of endmembers per class in the simulated spectra [list[integer]]>
+  n_components:
+    soil: [1,2,3]     <random choice for number of components per sample for class [list[integer]]>
+    pv:   [1,2,3]     <random choice for number of components per sample for class [list[integer]]>
+    npv:  [1,2,3,4,5] <random choice for number of components per sample for class [list[integer]]>
   n_classes_in_subsets: <number of classes in the simulated spectra [integer]>
-  alpha:                <alpha parameter for Dirichlet distribution [float]>
-  min-frac:             <minimum fraction of class presence to be included in simulation [float]>
-  noise-file:           <path to noise CSV file of covariances [string]>
+  min_frac:             <minimum fraction of class presence to be included in simulation [float]>
+  alpha_uniform_low:    <Dirichlet distribution alpha low value [float]>
+  alpha_uniform_high:   <Dirichlet distribution alpha low value [float]>
+  white_noise:          <white noise scalar [float]>
+  noise_covariance_csv: <path to the noise covaraince csv file [string]>
+  return_fractions:     <return the dirichlet fractions from the simulation [boolean]>
+  glint_upper_scalar:   <upper bound for water class glint scalar [float]>
+  glint_lower_scalar:   <lower bound for water class glint scalar [float]>
 subsample:
   test-fraction:   <test data split fraction [float]>
   selected-method: <subsampling method to use [string]>
+  file-specific:
+    /some/path.hdf5:
+        kmedoids:
   convex-hull:
     ...
   kmeans:
@@ -51,6 +66,10 @@ subsample:
     ...
   lhs:
     ...
+dataloader:
+  percent-static-data: 0.5
+test-scene-urls:
+    - https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/some-fid
 ```
 
 All of the fields in each of the `subsample` methods in the `dataloader.yml` are the names of a parameter and the value of that parameter to be passed into the corresponding subsampling function

--- a/src/cover_class/config/README.md
+++ b/src/cover_class/config/README.md
@@ -46,9 +46,9 @@ simulation:
   n_classes_in_subsets: <number of classes in the simulated spectra [integer]>
   min_frac:             <minimum fraction of class presence to be included in simulation [float]>
   alpha_uniform_low:    <Dirichlet distribution alpha low value [float]>
-  alpha_uniform_high:   <Dirichlet distribution alpha low value [float]>
+  alpha_uniform_high:   <Dirichlet distribution alpha high value [float]>
   white_noise:          <white noise scalar [float]>
-  noise_covariance_csv: <path to the noise covaraince csv file [string]>
+  noise_covariance_csv: <path to the noise covariance csv file [string]>
   return_fractions:     <return the dirichlet fractions from the simulation [boolean]>
   glint_upper_scalar:   <upper bound for water class glint scalar [float]>
   glint_lower_scalar:   <lower bound for water class glint scalar [float]>

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -15,7 +15,10 @@ datasets:
   water:
 ood-test-set: /some/path.hdf5
 simulation:
-  n_components: [1,5]
+  n_components:
+    soil: [1,2,3]
+    pv: [1,2,3]
+    npv: [1,2,3,4,5]
   n_classes_in_subsets: 3
   alpha: 0.3
   min_frac: 0.1

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -49,7 +49,7 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         assert str(sim_config['noise_covariance_csv']).endswith('csv'), f"Noise covariance file does not end with .csv: {sim_config['noise_covariance_csv']}"
         noise_cov = np.genfromtxt(sim_config['noise_covariance_csv'], delimiter=',', dtype=float)
 
-    n_components: List[List[int]] = [n for n in sim_config['n_components'] if bool(config['datasets'].get(n, None))]
+    n_components: List[List[int]] = [v for k, v in sim_config['n_components'].items() if bool(config['datasets'].get(k, None))]
 
     s = SimulationArgs(
         n_iters = batch_size,

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -24,6 +24,7 @@ class SimulationArgs(Struct):
 
     def __post_init__(self):
         assert len(self.n_components) == self.n_classes, f"Number of classes, {self.n_classes}, must match the number of component sampling ranges, {len(self.n_components)}"
+        assert all(len(i) for i in self.n_components), "All classes must have a non-empty value for the `n_components` config"
 
     def to(self, device: torch.device):
         if self.noise_covariance is not None: 

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -49,7 +49,11 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         assert str(sim_config['noise_covariance_csv']).endswith('csv'), f"Noise covariance file does not end with .csv: {sim_config['noise_covariance_csv']}"
         noise_cov = np.genfromtxt(sim_config['noise_covariance_csv'], delimiter=',', dtype=float)
 
-    n_components: List[List[int]] = [v for k, v in sim_config['n_components'].items() if bool(config['datasets'].get(k, None))]
+    n_components: List[List[int]] = [
+        sim_config['n_components'][dataset_name]
+        for dataset_name, enabled in config['datasets'].items()
+        if enabled and dataset_name in sim_config['n_components']
+    ]
 
     s = SimulationArgs(
         n_iters = batch_size,

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -11,7 +11,7 @@ class SimulationArgs(Struct):
     n_iters: int
     n_classes: int
     n_classes_in_subsets: int
-    n_components: List[int] # per class
+    n_components: List[List[int]]
     min_frac: float
     alpha: Optional[float]
     alpha_uniform_low: float
@@ -21,6 +21,9 @@ class SimulationArgs(Struct):
     return_fractions: bool
     glint_scalar_range: Tuple[Optional[float], Optional[float]]
     water_classes: List[int]
+
+    def __post_init__(self):
+        assert len(self.n_components) == self.n_classes, f"Number of classes, {self.n_classes}, must match the number of component sampling ranges, {len(self.n_components)}"
 
     def to(self, device: torch.device):
         if self.noise_covariance is not None: 
@@ -46,12 +49,14 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         assert str(sim_config['noise_covariance_csv']).endswith('csv'), f"Noise covariance file does not end with .csv: {sim_config['noise_covariance_csv']}"
         noise_cov = np.genfromtxt(sim_config['noise_covariance_csv'], delimiter=',', dtype=float)
 
+    n_components: List[List[int]] = [n for n in sim_config['n_components'] if bool(config['datasets'].get(n, None))]
+
     s = SimulationArgs(
         n_iters = batch_size,
         n_classes = n_classes,
         n_classes_in_subsets = sim_config['n_classes_in_subsets'],
         min_frac = sim_config['min_frac'],
-        n_components = sim_config['n_components'],
+        n_components = n_components,
         alpha = sim_config['alpha'],
         alpha_uniform_low = sim_config['alpha_uniform_low'],
         alpha_uniform_high = sim_config['alpha_uniform_high'],

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -117,7 +117,7 @@ def run_simulation(
             classes,
             data_args.real_labels,
             sim_args.n_classes,
-            max(sim_args.n_components),
+            max([max(i) for i in sim_args.n_components]),
             simulation_space_size[1],
         )
 
@@ -165,7 +165,12 @@ def _0_init_simulation_state(
         indices.to(dtype=torch.int8)
     )
 
-    n_components_numpy: npt.NDArray[np.int32] = np.random.choice(sim_args.n_components, size, replace=True).astype(np.int32)
+    classes_cpu = classes.to(dtype=torch.int64, device=device).numpy()
+    n_components_numpy: npt.NDArray[np.int32] = np.empty(size, dtype=np.int32)
+    for c in np.unique(classes_cpu):
+        mask = (classes_cpu == c)
+        vals = np.asarray(sim_args.n_components[c], dtype=np.int32)
+        n_components_numpy[mask] = np.random.choice(vals, mask.sum(), replace=True)
     n_components = torch.from_numpy(n_components_numpy).to(dtype=torch.int64, device=device)
 
     if force_class is not None:

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -166,7 +166,7 @@ def _0_init_simulation_state(
     )
 
     classes_cpu = classes.to(dtype=torch.int64, device=device).numpy()
-    n_components_numpy: npt.NDArray[np.int32] = np.empty(size, dtype=np.int32)
+    n_components_numpy: npt.NDArray[np.int32] = np.zeros(size, dtype=np.int32)
     for c in np.unique(classes_cpu):
         mask = (classes_cpu == c)
         vals = np.asarray(sim_args.n_components[c], dtype=np.int32)

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -165,7 +165,7 @@ def _0_init_simulation_state(
         indices.to(dtype=torch.int8)
     )
 
-    classes_cpu = classes.to(dtype=torch.int64, device=device).numpy()
+    classes_cpu = classes.to(dtype=torch.int64).cpu().numpy()
     n_components_numpy: npt.NDArray[np.int32] = np.zeros(size, dtype=np.int32)
     for c in np.unique(classes_cpu):
         mask = (classes_cpu == c)

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -33,6 +33,8 @@ def new_sim_args() -> Tuple[SimulationArgs, DataArgs]:
         white_noise = 0.,
         noise_covariance = None,
         return_fractions = False,
+        glint_scalar_range = [None, None],
+        water_classes=[],
     ),
     None)
     # DataArgs(torch.tensor([.1, .2, .3]), torch.tensor([.1, .2, .3])))

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from cover_class.dataloader import OrchestratorDataset, OrchestratorDatasetArgs # type: ignore[import]
-from cover_class.simulation import SimulationArgs, DataArgs
+from cover_class.simulation import SimulationArgs, DataArgs # type: ignore[import]
 
 RANDOM_SEED = 42
 

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -9,12 +9,14 @@ from cover_class.simulation.simulate import force_fractions, _0_init_simulation_
 
 RANDOM_SEED = 42
 
+N_CLASSES = 10
+
 def new_SimulationArgs() -> SimulationArgs:
     return SimulationArgs(
         n_iters = 100,
         n_classes_in_subsets = 5,
-        n_classes = 10,
-        n_components = list(range(10)),
+        n_classes = N_CLASSES,
+        n_components = list([range(10) for _ in range(N_CLASSES)]),
         min_frac = 0.,
         alpha = None,
         alpha_uniform_low = 0.,
@@ -22,6 +24,8 @@ def new_SimulationArgs() -> SimulationArgs:
         white_noise = 0.,
         noise_covariance = None,
         return_fractions = False,
+        glint_scalar_range = [None, None],
+        water_classes = [],
     )
 
 
@@ -46,7 +50,7 @@ class simulationTest(unittest.TestCase):
         # 1. `cumsum_n_components` should be monotomically increasing on a per-row basis and should all be in sim_args.n_components
         differences = torch.diff(cumsum_n_components, axis=1)
         self.assertTrue((differences >= 0).all().item())
-        self.assertTrue(torch.isin(torch.unique(differences), torch.tensor(sim_args.n_components)).all().item())
+        self.assertTrue(torch.isin(torch.unique(differences), torch.tensor([i for s in sim_args.n_components for i in s])).all().item())
         # 2. `cumsum_n_components` have the first value in every row be zero
         self.assertTrue((cumsum_n_components[:, 0] == 0).all().item())
 
@@ -206,11 +210,12 @@ class simulationTest(unittest.TestCase):
                 self.assertListEqual(counts.tolist(), expected_num_classes.tolist())
 
         with self.subTest("test_function_receives_expected_input"):
+            n_classes = 5
             sim_args = SimulationArgs(
                 n_iters=1,
                 n_classes_in_subsets=2,
-                n_classes=5,
-                n_components=[1, 2, 3],
+                n_classes=n_classes,
+                n_components=[[1, 2, 3] for _ in range(n_classes)],
                 min_frac=0.0,
                 alpha=0.3,
                 alpha_uniform_low=0.0,
@@ -218,6 +223,8 @@ class simulationTest(unittest.TestCase):
                 white_noise=0.0,
                 noise_covariance=None,
                 return_fractions=False,
+                glint_scalar_range = [None, None],
+                water_classes = [],
             )
 
             data_args = DataArgs(
@@ -264,7 +271,7 @@ class simulationTest(unittest.TestCase):
             torch.testing.assert_close(captured["classes"], classes)
             torch.testing.assert_close(captured["labels"], data_args.real_labels)
             self.assertEqual(captured["n_classes"], sim_args.n_classes)
-            self.assertEqual(captured["n_components_max"], max(sim_args.n_components))
+            self.assertEqual(captured["n_components_max"], max([max(i) for i in sim_args.n_components]))
             self.assertEqual(captured["dirichlet_2nd_dim_shape"], cumsum_n_components.max().item())
 
     def test_5_make_sim_spectra(self):
@@ -309,12 +316,13 @@ class simulationTest(unittest.TestCase):
         with self.subTest("test_function_receives_expected_input"):
             N = 10
             cov = torch.eye(N)
+            n_classes = 3
 
             sim_args = SimulationArgs(
                 n_iters=1,
                 n_classes_in_subsets=2,
-                n_classes=3,
-                n_components=[1, 2, 3],
+                n_classes=n_classes,
+                n_components=[[1, 2, 3] for _ in range(n_classes)],
                 min_frac=0.0,
                 alpha=0.3,
                 alpha_uniform_low=0.0,
@@ -322,6 +330,8 @@ class simulationTest(unittest.TestCase):
                 white_noise=123.45,
                 noise_covariance=cov,
                 return_fractions=False,
+                glint_scalar_range = [None, None],
+                water_classes = [],
             )
             data_args = DataArgs(torch.ones((120,N), dtype=torch.float32), torch.tensor(list(range(10))*12))
 
@@ -418,12 +428,13 @@ class simulationTest(unittest.TestCase):
     def test_0_init_simulation_state_force_class(self):
         torch.manual_seed(0)
 
+        n_classes = 50
         class SimArgs:
             def __init__(self):
                 self.n_iters = 64
                 self.n_classes_in_subsets = 6
                 self.n_classes = 50
-                self.n_components = [0, 1, 2, 3, 4]
+                self.n_components = [[0, 1, 2, 3, 4] for _ in range(n_classes)]
 
         sim_args = SimArgs()
         device = torch.device("cpu")

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -16,7 +16,7 @@ def new_SimulationArgs() -> SimulationArgs:
         n_iters = 100,
         n_classes_in_subsets = 5,
         n_classes = N_CLASSES,
-        n_components = list([range(10) for _ in range(N_CLASSES)]),
+        n_components = [list(range(10)) for _ in range(N_CLASSES)],
         min_frac = 0.,
         alpha = None,
         alpha_uniform_low = 0.,


### PR DESCRIPTION
## Overview
This PR alters the `n_components` config parameter to now allow specifying the number of components per class. Perviously, the config set a global standard for how many components per class there are, but now that is customizable on a per-class basis. As a result, per simulation, there could be a variable number of classes from each specific class.

Below is an example of how that looks in the config:
```
simulation:
  n_components:
    soil: [1,2,3]
    pv: [1,2,3]
    npv: [1,2,3,4,5]
```

## Testing
1. Altered regression tests and proved their passing
2. Debugging step through with `python3 models/training_example.py --outdir . --config /path/to/dataloader.yml --lr 0.0001 --batch-size 1024 --max-training-steps 100 --log-interval 20 --simulated-test-set-size 1000 --seed 42` to confirm that the correct class components were being sampled. 