### PR TITLE
Noise Scalar

### DIFF
--- a/src/cover_class/config/README.md
+++ b/src/cover_class/config/README.md
@@ -40,6 +40,7 @@ simulation:
   alpha:                <alpha parameter for Dirichlet distribution [float]>
   min-frac:             <minimum fraction of class presence to be included in simulation [float]>
   noise-file:           <path to noise CSV file of covariances [string]>
+  noise_scalar:         <scalar to apply to the CSV file noise>
 subsample:
   test-fraction:   <test data split fraction [float]>
   selected-method: <subsampling method to use [string]>

--- a/src/cover_class/config/README.md
+++ b/src/cover_class/config/README.md
@@ -48,7 +48,7 @@ simulation:
   alpha_uniform_low:    <Dirichlet distribution alpha low value [float]>
   alpha_uniform_high:   <Dirichlet distribution alpha high value [float]>
   white_noise:          <white noise scalar [float]>
-  noise_scalar:         <optional scalar to apply to the whole noise>
+  noise_scalar:         <optional scalar to apply to the CSV noise>
   noise_covariance_csv: <path to the noise covariance csv file [string]>
   return_fractions:     <return the dirichlet fractions from the simulation [boolean]>
   glint_upper_scalar:   <upper bound for water class glint scalar [float]>

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -22,6 +22,7 @@ simulation:
   alpha_uniform_low: 0.1
   alpha_uniform_high: 10.
   white_noise: 0.0001
+  noise_scalar: 
   noise_covariance_csv: static/spectral_noise_covariances.csv
   return_fractions: false
   glint_upper_scalar:

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -17,6 +17,7 @@ class SimulationArgs(Struct):
     alpha_uniform_low: float
     alpha_uniform_high: float
     white_noise: float
+    noise_scalar: Optional[float]
     noise_covariance: Optional[FloatTensor]
     return_fractions: bool
     glint_scalar_range: Tuple[Optional[float], Optional[float]]
@@ -56,6 +57,7 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         alpha_uniform_low = sim_config['alpha_uniform_low'],
         alpha_uniform_high = sim_config['alpha_uniform_high'],
         white_noise = sim_config['white_noise'],
+        noise_scalar = sim_config['noise_scalar'],
         noise_covariance = FloatTensor(torch.from_numpy(noise_cov).to(torch.float32)) if noise_cov is not None else None,
         return_fractions=sim_config["return_fractions"],
         glint_scalar_range=(sim_config["glint_lower_scalar"], sim_config["glint_upper_scalar"]),

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -344,16 +344,16 @@ def _6_add_noise(
         if not (torch.linalg.eigvals(sim_args_noise).real>=0).all():
             sim_args_noise = make_positive_definite(sim_args_noise)
         means = torch.zeros(sim_args_noise.shape[0], dtype=torch.float32, device=device)
-        noise = torch.distributions.MultivariateNormal(means, covariance_matrix=sim_args_noise).sample((n_iters,))
+        noise = torch.distributions.MultivariateNormal(means, covariance_matrix=sim_args_noise).sample((n_iters,)) * noise_scalar
         
         # add white noise
         white_noise = torch.normal(mean=means.expand(n_iters, -1), std=float(white_noise_scale))
         noise = noise + white_noise
         
     else:
-        noise = torch.zeros(n_iters, wavelength_dim, dtype=torch.float32, device=device)
+        noise = torch.zeros(n_iters, wavelength_dim, dtype=torch.float32, device=device) * noise_scalar
 
-    return noise.to(dtype=torch.float32) * noise_scalar  # type: ignore[return-value]
+    return noise.to(dtype=torch.float32)  # type: ignore[return-value]
 
 
 def make_positive_definite(A: Tensor, min_eigen=1e-8) -> FloatTensor:

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -133,6 +133,7 @@ def run_simulation(
             sim_args.noise_covariance,
             sim_args.n_iters,
             real_spectra.shape[1], 
+            sim_args.noise_scalar if sim_args.noise_scalar is not None else 1.,
             sim_args.white_noise,
             device
         )
@@ -328,6 +329,7 @@ def _6_add_noise(
         sim_args_noise:    Optional[torch.FloatTensor],
         n_iters:           int,
         wavelength_dim:    int,
+        noise_scalar:      float,
         white_noise_scale: float,
         device:            Device
 
@@ -346,7 +348,7 @@ def _6_add_noise(
     else:
         noise = torch.zeros(n_iters, wavelength_dim, dtype=torch.float32, device=device)
 
-    return noise.to(dtype=torch.float32)  # type: ignore[return-value]
+    return noise.to(dtype=torch.float32) * noise_scalar  # type: ignore[return-value]
 
 
 def make_positive_definite(A: Tensor, min_eigen=1e-8) -> FloatTensor:

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from cover_class.dataloader import OrchestratorDataset, OrchestratorDatasetArgs # type: ignore[import]
-from cover_class.simulation import SimulationArgs, DataArgs
+from cover_class.simulation import SimulationArgs, DataArgs # type: ignore[import]
 
 RANDOM_SEED = 42
 
@@ -31,6 +31,7 @@ def new_sim_args() -> Tuple[SimulationArgs, DataArgs]:
         alpha_uniform_low = 0.,
         alpha_uniform_high = 0.,
         white_noise = 0.,
+        noise_scalar=None,
         noise_covariance = None,
         return_fractions = False,
     ),

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -20,12 +20,13 @@ def make_odsa(bsz, percent, s, d, sd, sl) -> OrchestratorDatasetArgs:
     )
 
 def new_sim_args() -> Tuple[SimulationArgs, DataArgs]:
+    n_classes = 10
     return (
     SimulationArgs(
         n_iters = 100,
         n_classes_in_subsets = 5,
         n_classes = 10,
-        n_components = list(range(10)),
+        n_components = [list(range(10)) for _ in range(n_classes)],
         min_frac = 0.,
         alpha = None,
         alpha_uniform_low = 0.,

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -307,12 +307,12 @@ class simulationTest(unittest.TestCase):
 
         with self.subTest("test_function_works_as_expected"):
             n_components = 10
-            noise = simulate._6_add_noise(None, 1, n_components, 0., None)
+            noise = simulate._6_add_noise(None, 1, n_components, 1., 0., None)
             torch.testing.assert_close(noise, torch.zeros((1, n_components,)))
 
             N = 10
             cov = torch.eye(N)
-            noise = simulate._6_add_noise(cov, 1, n_components, 0.4, None)
+            noise = simulate._6_add_noise(cov, 1, n_components, 1., 0.4, None)
             self.assertEqual(noise.shape, (1, N))
 
         with self.subTest("test_function_receives_expected_input"):
@@ -340,7 +340,7 @@ class simulationTest(unittest.TestCase):
 
             obtained_noise_cov, obtained_white_noise, obtained_wavelength_dim, obtained_n_iters = None, None, None, None
                                     
-            def mock_add_noise(sim_args_noise, n_iters, wavelength_dim, white_noise_scale, _):
+            def mock_add_noise(sim_args_noise, n_iters, wavelength_dim, noise_scalar, white_noise_scale, _):
                 nonlocal obtained_noise_cov, obtained_white_noise, obtained_wavelength_dim, obtained_n_iters
                 obtained_noise_cov = sim_args_noise
                 obtained_white_noise = white_noise_scale

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -20,6 +20,7 @@ def new_SimulationArgs() -> SimulationArgs:
         alpha_uniform_low = 0.,
         alpha_uniform_high = 0.,
         white_noise = 0.,
+        noise_scalar=None,
         noise_covariance = None,
         return_fractions = False,
     )
@@ -216,6 +217,7 @@ class simulationTest(unittest.TestCase):
                 alpha_uniform_low=0.0,
                 alpha_uniform_high=0.0,
                 white_noise=0.0,
+                noise_scalar=None,
                 noise_covariance=None,
                 return_fractions=False,
             )
@@ -320,6 +322,7 @@ class simulationTest(unittest.TestCase):
                 alpha_uniform_low=0.0,
                 alpha_uniform_high=0.0,
                 white_noise=123.45,
+                noise_scalar=None,
                 noise_covariance=cov,
                 return_fractions=False,
             )


### PR DESCRIPTION
## Overview
This PR adds in a new configuration to alter the amount of noise per simulation. The new config parameter can be any float value or `None`. If it is `None`, no scalar will be applied. 

## Testing
- regression tests all pass