### PR TITLE
Option to Multiply Each Class By a Scalar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 __pycache__/
 
 */wandb/
+**/wandb

--- a/src/cover_class/config/README.md
+++ b/src/cover_class/config/README.md
@@ -51,8 +51,17 @@ simulation:
   noise_scalar:         <optional scalar to apply to the CSV noise>
   noise_covariance_csv: <path to the noise covariance csv file [string]>
   return_fractions:     <return the dirichlet fractions from the simulation [boolean]>
-  glint_upper_scalar:   <upper bound for water class glint scalar [float]>
-  glint_lower_scalar:   <lower bound for water class glint scalar [float]>
+  glint_upper_constant:   <upper bound for water class glint scalar [float]>
+  glint_lower_constant:   <lower bound for water class glint scalar [float]>
+  magnitude_max:        <upper bound on the allowed spectra values after the multiplcation operation from `scalars`>
+  scalars:             <randomly generates a scalar between a high and low value to multiply each class by. leave blank to do no multiplication>
+    soil:
+      low: 0.1
+      high: 0.25
+    ...
+  forced_fraction_test_set:
+    soil: [[0.01, 0.05], [0.05, 0.10], [0.10, 0.15], [0.15, 0.25], [0.25, 0.50]]
+    ...
 subsample:
   test-fraction:   <test data split fraction [float]>
   selected-method: <subsampling method to use [string]>

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -28,8 +28,19 @@ simulation:
   noise_scalar: 
   noise_covariance_csv: static/spectral_noise_covariances.csv
   return_fractions: false
-  glint_upper_scalar:
-  glint_lower_scalar:
+  glint_upper_constant:
+  glint_lower_constant:
+  magnitude_max: 1.5
+  scalars:
+    soil:
+      low: 0.1
+      high: 0.25
+    pv:
+      low: 0.3
+      high: 0.5
+    npv:
+      low:
+      high:
   forced_fraction_test_set:
     soil: [[0.01, 0.05], [0.05, 0.10], [0.10, 0.15], [0.15, 0.25], [0.25, 0.50]]
     pv: [[0.01, 0.05], [0.05, 0.10], [0.10, 0.15], [0.15, 0.25], [0.25, 0.50]]

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -51,7 +51,11 @@ class DataArgs(Struct):
 def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, batch_size:int) -> Tuple[SimulationArgs, DataArgs]:
     config = read_config(config)
     sim_config:dict = config['simulation']
-    n_classes = sum(map(bool, config['datasets'].values()))
+
+    # Determine enabled datasets in a single place to ensure consistent ordering
+    enabled_datasets = [dataset_name for dataset_name, enabled in config['datasets'].items() if enabled]
+    n_classes = len(enabled_datasets)
+
     noise_cov = None
     if sim_config['noise_covariance_csv']:
         assert str(sim_config['noise_covariance_csv']).endswith('csv'), f"Noise covariance file does not end with .csv: {sim_config['noise_covariance_csv']}"
@@ -59,14 +63,15 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
 
     n_components: List[List[int]] = [
         sim_config['n_components'][dataset_name]
-        for dataset_name, enabled in config['datasets'].items()
-        if enabled and dataset_name in sim_config['n_components']
+        for dataset_name in enabled_datasets
+        if dataset_name in sim_config['n_components']
     ]
 
-    class_names = [c for c,v in config['datasets'].items() if v is not None]
+    class_names = enabled_datasets
     ffracs = sim_config.get("forced_fraction_test_set", {})
 
-    scalars = [(sim_config["scalars"] or {}).get(k, ()) for k in list(config['datasets'].keys())]
+    scalars_config = sim_config.get("scalars") or {}
+    scalars = [scalars_config.get(dataset_name, ()) for dataset_name in enabled_datasets]
     scalars = [(i.get('low', None), i.get('high', None)) if isinstance(i, dict) else i for i in scalars]
 
     s = SimulationArgs(

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -67,7 +67,7 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
     ffracs = sim_config.get("forced_fraction_test_set", {})
 
     scalars = [(sim_config["scalars"] or {}).get(k, ()) for k in list(config['datasets'].keys())]
-    scalars = [(i.get('high', None), i.get('low', None)) if isinstance(i, dict) else i for i in scalars]
+    scalars = [(i.get('low', None), i.get('high', None)) if isinstance(i, dict) else i for i in scalars]
 
     s = SimulationArgs(
         n_iters = batch_size,

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -20,8 +20,10 @@ class SimulationArgs(Struct):
     noise_scalar: Optional[float]
     noise_covariance: Optional[FloatTensor]
     return_fractions: bool
-    glint_scalar_range: Tuple[Optional[float], Optional[float]]
+    glint_constant_range: Tuple[Optional[float], Optional[float]]
     water_classes: List[int]
+    class_scalar_ranges: List[Tuple[Optional[float], Optional[float]]]
+    magnitude_max: Optional[float]
     class_names: List[str]
     forced_fractions: Dict[str, List[Tuple[float,float]]]
 
@@ -29,6 +31,7 @@ class SimulationArgs(Struct):
         assert len(self.n_components) == self.n_classes, f"Number of classes, {self.n_classes}, must match the number of component sampling ranges, {len(self.n_components)}"
         assert all(len(i) for i in self.n_components), "All classes must have a non-empty value for the `n_components` config"
         assert isinstance(self.forced_fractions, dict), "simulation/forced_fraction_test_set needs to contain key-value pairs"
+        assert len(self.class_scalar_ranges) == self.n_classes, "Need to have a scalar range for every class, even if it is 'None'. SimulationArgs was not properly generated"
 
     def to(self, device: torch.device):
         if self.noise_covariance is not None: 
@@ -63,6 +66,9 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
     class_names = [c for c,v in config['datasets'].items() if v is not None]
     ffracs = sim_config.get("forced_fraction_test_set", {})
 
+    scalars = [(sim_config["scalars"] or {}).get(k, ()) for k in list(config['datasets'].keys())]
+    scalars = [(i.get('high', None), i.get('low', None)) if isinstance(i, dict) else i for i in scalars]
+
     s = SimulationArgs(
         n_iters = batch_size,
         n_classes = n_classes,
@@ -76,8 +82,10 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         noise_scalar = sim_config['noise_scalar'],
         noise_covariance = FloatTensor(torch.from_numpy(noise_cov).to(torch.float32)) if noise_cov is not None else None,
         return_fractions = sim_config["return_fractions"],
-        glint_scalar_range = (sim_config["glint_lower_scalar"], sim_config["glint_upper_scalar"]),
+        glint_constant_range = (sim_config["glint_lower_constant"], sim_config["glint_upper_constant"]),
         water_classes = [i for i in range(len(config['datasets'])) if 'water' in list(config['datasets'].keys())[i].lower()],
+        class_scalar_ranges = scalars,
+        magnitude_max=sim_config["magnitude_max"],
         class_names = class_names,
         forced_fractions = ffracs,
     )

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -22,12 +22,9 @@ from cover_class.simulation.args import SimulationArgs, DataArgs, ForceFracRange
 ALPHA_MASKOUT_VALUE = torch.tensor(2 ** -126, dtype=torch.float32)
 NULL_CLASS_VALUE = -1
 
-def appy_water_scalar(data_args: DataArgs, glint_scalar_range: Tuple[Optional[float], Optional[float]], water_classes: List[int]) -> FloatTensor:
-    labels = data_args.real_labels
-    spectra = data_args.real_spectra
-
-    lo, hi = glint_scalar_range
-    if lo is None or hi is None or len(water_classes) == 0: 
+def apply_glint_offset(spectra: FloatTensor, labels: Tensor, glint_constant_range: Tuple[Optional[float], Optional[float]], water_classes: List[int]) -> FloatTensor:
+    lo, hi = glint_constant_range
+    if lo is None or hi is None or (len(water_classes) == 0) or (lo == hi == 0.0): 
         return spectra
     lo, hi = (hi, lo) if hi < lo else (lo, hi)
 
@@ -36,10 +33,33 @@ def appy_water_scalar(data_args: DataArgs, glint_scalar_range: Tuple[Optional[fl
         return spectra
     
     s = lo + (hi - lo) * torch.rand(spectra.size(0), device=spectra.device, dtype=spectra.dtype)
-    X = spectra.clone()
-    X[m] += s[m].unsqueeze(-1)
-    return FloatTensor(X)
+    spectra[m] += s[m].unsqueeze(-1)
+    return spectra
 
+def augment_magnitude(spectra: FloatTensor, labels: Tensor, class_scalar_ranges: List[Tuple[Optional[float], Optional[float]]], magnitude_max: Optional[float]) -> FloatTensor:
+    assert len(class_scalar_ranges) == labels.shape[-1], "The number of class magnitude scalars needs to be equal to the number of classes, even if the scalars are 'None' for that class."
+    for i, magnitude_range in enumerate(class_scalar_ranges):
+        if magnitude_range is None or len(magnitude_range) == 0:
+            continue
+
+        lo, hi = magnitude_range
+        if lo == hi == 1.0 or lo is None or hi is None:
+            continue
+        lo, hi = (hi, lo) if hi < lo else (lo, hi)
+
+        m = labels[..., None].eq(i).any(-1)
+        if not m.any():
+            continue
+
+        num = int(m.sum())
+        s = lo + (hi - lo) * torch.rand(num, device=spectra.device, dtype=spectra.dtype)
+
+        if magnitude_max is not None:
+            spec_max = spectra[m].amax(dim=1)
+            s = torch.where(spec_max > 0, torch.minimum(s, magnitude_max / spec_max), s)
+
+        spectra[m] = spectra[m] * s.unsqueeze(-1)
+    return spectra
 
 def reduce_between(mask: BoolTensor, cumsum_n_components: LongTensor) -> ShortTensor:
     mask_pad = F.pad(mask.to(dtype=torch.int64, device=mask.device).cumsum_(dim=1), (1, 0), value=0) # pad left side with 0
@@ -62,7 +82,10 @@ def run_simulation(
     sim_args.to(device)
     data_args.to(device)
 
-    real_spectra = appy_water_scalar(data_args, sim_args.glint_scalar_range, sim_args.water_classes)
+    real_spectra = data_args.real_spectra.clone()
+    real_labels  = data_args.real_labels
+    real_spectra = apply_glint_offset(real_spectra, real_labels, sim_args.glint_constant_range, sim_args.water_classes) # type: ignore
+    real_spectra = augment_magnitude(real_spectra, real_labels, sim_args.class_scalar_ranges, sim_args.magnitude_max)
 
     with torch.no_grad():
         classes, cumsum_n_components = _0_init_simulation_state(sim_args, device, force_class)

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -37,7 +37,6 @@ def apply_glint_offset(spectra: FloatTensor, labels: Tensor, glint_constant_rang
     return spectra
 
 def augment_magnitude(spectra: FloatTensor, labels: Tensor, class_scalar_ranges: List[Tuple[Optional[float], Optional[float]]], magnitude_max: Optional[float]) -> FloatTensor:
-    assert len(class_scalar_ranges) == labels.shape[-1], "The number of class magnitude scalars needs to be equal to the number of classes, even if the scalars are 'None' for that class."
     for i, magnitude_range in enumerate(class_scalar_ranges):
         if magnitude_range is None or len(magnitude_range) == 0:
             continue

--- a/tests/dataloader/dataloader_test.py
+++ b/tests/dataloader/dataloader_test.py
@@ -35,7 +35,7 @@ def new_sim_args() -> Tuple[SimulationArgs, DataArgs]:
         noise_scalar=None,
         noise_covariance = None,
         return_fractions = False,
-        glint_scalar_range = [None, None],
+        glint_constant_range = [None, None],
         water_classes=[],
     ),
     None)

--- a/tests/simulation/simulate_test.py
+++ b/tests/simulation/simulate_test.py
@@ -25,7 +25,7 @@ def new_SimulationArgs() -> SimulationArgs:
         noise_scalar=None,
         noise_covariance = None,
         return_fractions = False,
-        glint_scalar_range = [None, None],
+        glint_constant_range = [None, None],
         water_classes = [],
     )
 
@@ -225,7 +225,7 @@ class simulationTest(unittest.TestCase):
                 noise_scalar=None,
                 noise_covariance=None,
                 return_fractions=False,
-                glint_scalar_range = [None, None],
+                glint_constant_range = [None, None],
                 water_classes = [],
             )
 
@@ -333,7 +333,7 @@ class simulationTest(unittest.TestCase):
                 noise_scalar=None,
                 noise_covariance=cov,
                 return_fractions=False,
-                glint_scalar_range = [None, None],
+                glint_constant_range = [None, None],
                 water_classes = [],
             )
             data_args = DataArgs(torch.ones((120,N), dtype=torch.float32), torch.tensor(list(range(10))*12))


### PR DESCRIPTION
## Overview
This PR adds in the functionality to multiply each class by its own scalar values. 

To implement this change, change the dataloader config to have the ranges you want each class to be multiplied by, and set the maximum spectra value so no class exceeds a reasonable value.

```
  magnitude_max: 1.5
  scalars:
    soil:
      low: 0.1
      high: 0.25
    pv:
      low: 0.3
      high: 0.5
    npv:
      low:
      high:
```