### PR TITLE
Add in config reporting to PDF and JSON

### DIFF
--- a/src/cover_class/reporting/json_report.py
+++ b/src/cover_class/reporting/json_report.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, TYPE_CHECKING
 import json
 
+from cover_class.utils import read_config
 if TYPE_CHECKING:
     from cover_class.reporting import Report
 
@@ -25,5 +26,6 @@ def generate_json_report(
             'Hyperparameters':report_config.model_config.hyperparams,
         }
     })
+    out.update({'Config':read_config(report_config.config)})
     with open(json_path, 'w') as f:
         json.dump(out, f, indent=4)

--- a/src/cover_class/reporting/pdf_report.py
+++ b/src/cover_class/reporting/pdf_report.py
@@ -1,5 +1,5 @@
 
-gfrom typing import Any, List, Dict, Optional, TYPE_CHECKING
+from typing import Any, List, Dict, Optional, TYPE_CHECKING
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap

--- a/src/cover_class/reporting/pdf_report.py
+++ b/src/cover_class/reporting/pdf_report.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Dict, Optional, TYPE_CHECKING
+
+gfrom typing import Any, List, Dict, Optional, TYPE_CHECKING
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
@@ -250,7 +251,7 @@ def generate_pdf_report(
                 ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
             ]))
     contents.append(table)
-    contents.append(Spacer(1, 0.5 * inch))
+    contents.append(PageBreak())
     ###############################################
 
 

--- a/src/cover_class/reporting/pdf_report.py
+++ b/src/cover_class/reporting/pdf_report.py
@@ -8,6 +8,8 @@ from numpy.typing import NDArray
 import math
 import os
 import warnings
+import json
+from xml.sax.saxutils import escape
 
 from reportlab.lib.pagesizes import LETTER # type: ignore[import]
 from reportlab.lib import colors # type: ignore[import]
@@ -23,6 +25,7 @@ from reportlab.platypus import ( # type: ignore[import]
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle, StyleSheet1 # type: ignore[import]
 from reportlab.lib.units import inch # type: ignore[import]
 
+from cover_class.utils import read_config
 from cover_class.reporting.utils import inference_over_scene, rgb_from_scene
 if TYPE_CHECKING:
     from cover_class.reporting import Report, GenLinePlot
@@ -247,7 +250,7 @@ def generate_pdf_report(
                 ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
             ]))
     contents.append(table)
-    contents.append(PageBreak())
+    contents.append(Spacer(1, 0.5 * inch))
     ###############################################
 
 
@@ -281,6 +284,16 @@ def generate_pdf_report(
         except Exception as e:
             warnings.warn(f"Failed to do inference over scene: {scene}\nException: {e}")
             continue
+    contents.append(PageBreak())
+    ###############################################
+
+
+    ################# Config json: ################
+    contents.append(Paragraph("Config Json", report_styles["Heading1"]))
+    config_obj = read_config(report_config.config)
+    config_json = json.dumps(config_obj, indent=4, default=str)
+    config_json = escape(config_json).replace("\n", "<br/>").replace("  ", "&nbsp;&nbsp;")
+    contents.append(Paragraph(config_json, report_styles["Code"]))
     contents.append(PageBreak())
     ###############################################
 


### PR DESCRIPTION
## Overview
This PR adds in the `dataloader.yml` state to the PDF and JSON reports. This should make it easier to track what is going on.

Specifically, the config gets appended to the end of the PDF and JSON so it's not too distracting since it is long

#### PDF:
<img width="670" height="845" alt="Screenshot 2026-03-23 at 5 09 24 PM" src="https://github.com/user-attachments/assets/a92ec9f9-149c-477d-94ba-8ce9db7d5b8c" />

#### JSON:
<img width="887" height="899" alt="Screenshot 2026-03-23 at 5 09 54 PM" src="https://github.com/user-attachments/assets/5452deb7-8374-4b84-9b1d-a2f009e8ffa5" />
