### PR TITLE
[Minor] Add HDF5 export to report_spectf.py

### DIFF
--- a/models/spectf/report_spectf.py
+++ b/models/spectf/report_spectf.py
@@ -178,7 +178,7 @@ def run_report_generator(
 
     # OOD loop
     print("Evaluating on OOD validation set...")
-    y_hat_ood = np.zeros_like(ood_test_set_y, dtype=float)
+    y_hat_ood = np.zeros_like(ood_test_set_y, dtype=np.float32)
     for i, (batch_X, _) in enumerate(ood_dataloader):
         batch_X = batch_X.to(device=device, dtype=torch.float32)
         batch_X = torch.unsqueeze(batch_X, -1)
@@ -193,7 +193,7 @@ def run_report_generator(
         export_path = os.path.join(outdir, "y_hat_ood.h5")
         print(f"Exporting y_hat_ood to {export_path}...")
         with h5py.File(export_path, "w") as f:
-            f.create_dataset("y_hat_ood", data=y_hat_ood)
+            f.create_dataset("{timestamp}_y_hat_ood", data=y_hat_ood)
 
     # Fraction simulation
     ff_simulated_test_set_size = 100

--- a/models/spectf/report_spectf.py
+++ b/models/spectf/report_spectf.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import rich_click as click
 import yaml
 
+import h5py
 import numpy as np
 import torch
 from torch.utils.data import Dataset, DataLoader
@@ -73,12 +74,19 @@ class TestDataset(Dataset):
     help="Number of rows to generate for the simulated test set.",
     envvar=f'{ENV_VAR_PREFIX}_SIMULATED_TEST_SET_SIZE'
 )
+@click.option(
+    "--export",
+    is_flag=True,
+    default=False,
+    help="Export y_hat_ood to an HDF5 file in the output directory.",
+)
 def run_report_generator(
         outdir: str,
         data_config: str,
         model_config: str,
         model_weights: str,
-        simulated_test_set_size: int = 100_000
+        simulated_test_set_size: int = 100_000,
+        export: bool = False
     ):
 
     # Load model config
@@ -180,6 +188,12 @@ def run_report_generator(
             batch_y_hat = batch_y_hat.detach().cpu().numpy().astype(float)
             batch_len = len(batch_y_hat)
             y_hat_ood[i*bs:i*bs+batch_len] = batch_y_hat
+
+    if export:
+        export_path = os.path.join(outdir, "y_hat_ood.h5")
+        print(f"Exporting y_hat_ood to {export_path}...")
+        with h5py.File(export_path, "w") as f:
+            f.create_dataset("y_hat_ood", data=y_hat_ood)
 
     # Fraction simulation
     ff_simulated_test_set_size = 100

--- a/models/spectf/report_spectf.py
+++ b/models/spectf/report_spectf.py
@@ -178,7 +178,7 @@ def run_report_generator(
 
     # OOD loop
     print("Evaluating on OOD validation set...")
-    y_hat_ood = np.zeros_like(ood_test_set_y, dtype=np.float32)
+    y_hat_ood = np.zeros_like(ood_test_set_y, dtype=float)
     for i, (batch_X, _) in enumerate(ood_dataloader):
         batch_X = batch_X.to(device=device, dtype=torch.float32)
         batch_X = torch.unsqueeze(batch_X, -1)
@@ -193,7 +193,7 @@ def run_report_generator(
         export_path = os.path.join(outdir, "y_hat_ood.h5")
         print(f"Exporting y_hat_ood to {export_path}...")
         with h5py.File(export_path, "w") as f:
-            f.create_dataset("{timestamp}_y_hat_ood", data=y_hat_ood)
+            f.create_dataset(f"{timestamp}_y_hat_ood", data=y_hat_ood.astype(np.float32))
 
     # Fraction simulation
     ff_simulated_test_set_size = 100


### PR DESCRIPTION
This PR adds the ability to export OOD model predictions as an HDF5 to `report_spectf.py`. We intentionally avoid exporting sim test results because they are generated at runtime. The HDF5 produced here is aligned with the input OOD HDF5 and can be compared against the labels as-is.