### PR TITLE
Minor fixes and features

### DIFF
--- a/models/spectf/report_spectf.py
+++ b/models/spectf/report_spectf.py
@@ -157,7 +157,7 @@ def run_report_generator(
             hyperparams={
                 "learning_rate": m_config['training']['learning_rate'],
                 "batch_size": m_config['batch_size'],
-                "optimizer": "ScheduleFreeAdamW",
+                "optimizer": "AdamWScheduleFree",
                 "params": m_config['model']
             },
         ),

--- a/models/spectf/report_spectf.py
+++ b/models/spectf/report_spectf.py
@@ -197,10 +197,10 @@ def run_report_generator(
             y_hat_ood[i*bs:i*bs+batch_len] = batch_y_hat
 
     if export:
-        export_path = os.path.join(outdir, "y_hat_ood.h5")
+        export_path = os.path.join(outdir, f"{timestamp}_y_hat_ood.h5")
         print(f"Exporting y_hat_ood to {export_path}...")
         with h5py.File(export_path, "w") as f:
-            f.create_dataset(f"{timestamp}_y_hat_ood", data=y_hat_ood.astype(np.float32))
+            f.create_dataset("y_hat_ood", data=y_hat_ood.astype(np.float32))
 
     # Fraction simulation
     ff_simulated_test_set_size = 100

--- a/models/spectf/report_spectf.py
+++ b/models/spectf/report_spectf.py
@@ -56,7 +56,7 @@ class TestDataset(Dataset):
     "--model-config",
     required=True,
     type=click.Path(exists=True, dir_okay=False),
-    help="Path to the YAML config for the model.",
+    help="Path to the YAML config for the model architecture.",
     envvar=f'{ENV_VAR_PREFIX}_MODEL_CONFIG'
 )
 @click.option(
@@ -157,7 +157,7 @@ def run_report_generator(
             hyperparams={
                 "learning_rate": m_config['training']['learning_rate'],
                 "batch_size": m_config['batch_size'],
-                "optimizer": "AdamW",
+                "optimizer": "ScheduleFreeAdamW",
                 "params": m_config['model']
             },
         ),

--- a/models/spectf/scene_spectf.py
+++ b/models/spectf/scene_spectf.py
@@ -68,7 +68,7 @@ class RasterDataset(Dataset):
     "--model-config",
     required=True,
     type=click.Path(exists=True, dir_okay=False),
-    help="Path to the YAML config for the model.",
+    help="Path to the YAML config for the model architecture.",
     envvar=f'{ENV_VAR_PREFIX}_MODEL_CONFIG'
 )
 @click.option(

--- a/models/spectf/sweep_spectf.py
+++ b/models/spectf/sweep_spectf.py
@@ -210,7 +210,7 @@ def run_pipeline_classifier(
             hyperparams={
                 "learning_rate": m_config['training']['learning_rate'],
                 "batch_size": m_config['batch_size'],
-                "optimizer": optimizer.__name__,
+                "optimizer": optimizer.__class__.__name__,
                 "params": m_config['model']
             },
         ),

--- a/models/spectf/sweep_spectf.py
+++ b/models/spectf/sweep_spectf.py
@@ -59,7 +59,7 @@ class TestDataset(Dataset):
     "--model-config",
     required=True,
     type=click.Path(exists=True, dir_okay=False),
-    help="Path to the YAML config for the dataloader.",
+    help="Path to the YAML config for the model architecture.",
     envvar=f'{ENV_VAR_PREFIX}_MODEL_CONFIG'
 )
 @click.option(
@@ -210,7 +210,7 @@ def run_pipeline_classifier(
             hyperparams={
                 "learning_rate": m_config['training']['learning_rate'],
                 "batch_size": m_config['batch_size'],
-                "optimizer": optim.AdamW.__name__,
+                "optimizer": optimizer.__name__,
                 "params": m_config['model']
             },
         ),

--- a/models/spectf/training_spectf.py
+++ b/models/spectf/training_spectf.py
@@ -144,7 +144,7 @@ def run_pipeline_classifier(
             hyperparams={
                 "learning_rate": m_config['training']['learning_rate'],
                 "batch_size": m_config['batch_size'],
-                "optimizer": optimizer.__name__,
+                "optimizer": optimizer.__class__.__name__,
                 "params": m_config['model']
             },
         ),

--- a/models/spectf/training_spectf.py
+++ b/models/spectf/training_spectf.py
@@ -59,7 +59,7 @@ class TestDataset(Dataset):
     "--model-config",
     required=True,
     type=click.Path(exists=True, dir_okay=False),
-    help="Path to the YAML config for the dataloader.",
+    help="Path to the YAML config for the model architecture.",
     envvar=f'{ENV_VAR_PREFIX}_MODEL_CONFIG'
 )
 @click.option(
@@ -144,7 +144,7 @@ def run_pipeline_classifier(
             hyperparams={
                 "learning_rate": m_config['training']['learning_rate'],
                 "batch_size": m_config['batch_size'],
-                "optimizer": optim.AdamW.__name__,
+                "optimizer": optimizer.__name__,
                 "params": m_config['model']
             },
         ),

--- a/src/cover_class/config/dataloader.yml
+++ b/src/cover_class/config/dataloader.yml
@@ -25,6 +25,7 @@ simulation:
   alpha_uniform_low: 0.1
   alpha_uniform_high: 10.
   white_noise: 0.0001
+  noise_brightness_scaling: true
   noise_scalar: 
   noise_covariance_csv: static/spectral_noise_covariances.csv
   sim_mixture_probs_csv: config/sim-mixture-probs.csv

--- a/src/cover_class/simulation/args.py
+++ b/src/cover_class/simulation/args.py
@@ -18,6 +18,7 @@ class SimulationArgs(Struct):
     alpha_uniform_low: float
     alpha_uniform_high: float
     white_noise: float
+    noise_brightness_scaling: bool
     noise_scalar: Optional[float]
     noise_covariance: Optional[FloatTensor]
     sim_mixture_probs_matrix: Tensor
@@ -110,6 +111,7 @@ def args_from_config(config: Dict|str, data_matrix:FloatTensor, labels:Tensor, b
         alpha_uniform_low = sim_config['alpha_uniform_low'],
         alpha_uniform_high = sim_config['alpha_uniform_high'],
         white_noise = sim_config['white_noise'],
+        noise_brightness_scaling = sim_config['noise_brightness_scaling'],
         noise_scalar = sim_config['noise_scalar'],
         noise_covariance = FloatTensor(torch.from_numpy(noise_cov).to(torch.float32)) if noise_cov is not None else None,
         sim_mixture_probs_matrix = sim_mixture_probs_matrix,

--- a/src/cover_class/simulation/simulate.py
+++ b/src/cover_class/simulation/simulate.py
@@ -153,6 +153,7 @@ def run_simulation(
             real_spectra.shape[1], 
             sim_args.noise_scalar if sim_args.noise_scalar is not None else 1.,
             sim_args.white_noise,
+            sim_args.noise_brightness_scaling,
             device
         )
 
@@ -368,6 +369,7 @@ def _6_add_noise(
         wavelength_dim:    int,
         noise_scalar:      float,
         white_noise_scale: float,
+        noise_brightness_scaling: bool,
         device:            Device
 
     ) -> FloatTensor:
@@ -386,8 +388,9 @@ def _6_add_noise(
         noise = torch.zeros(n_iters, wavelength_dim, dtype=torch.float32, device=device) * noise_scalar
 
     # Roughly scale noise by spectral mean
-    spectral_mean = torch.mean(spectra, dim=1, keepdim=True)
-    noise = noise * spectral_mean
+    if noise_brightness_scaling:
+        spectral_mean = torch.mean(spectra, dim=1, keepdim=True)
+        noise = noise * spectral_mean
 
     return noise.to(dtype=torch.float32)  # type: ignore[return-value]
 


### PR DESCRIPTION
This PR contributes minor fixes and features identified during today's meetings.

* The OOD export feature for SpecTf report generation had the timestep in the HDF5 dataset name instead of the filename (#99)
* A small refactor fixed argument and config inconsistencies in SpecTf scripts (#100)
* A flag was added to enable/disable noise brightness scaling to test its impact on performance (#97)
